### PR TITLE
buildspec for akka-actor_2.13

### DIFF
--- a/content/com/typesafe/akka/akka-actor_2.13-2.6.4.buildspec
+++ b/content/com/typesafe/akka/akka-actor_2.13-2.6.4.buildspec
@@ -1,0 +1,15 @@
+scalaBinaryVersion=2.13
+scalaVersion=2.13.1
+
+groupId=com.typesafe.akka
+artifactId=akka-actor_${scalaBinaryVersion}
+version=2.6.4
+
+gitRepo=https://github.com/akka/akka
+gitTag=v${version}
+
+jdk=11
+build-tool=sbt
+
+command=sbt ++${scalaVersion} -Dakka.genjavadoc.enabled=true akka-actor/package
+buildinfo=/akka-actor/target/scala-${scalaBinaryVersion}/akka-actor_${scalaBinaryVersion}-${version}.buildinfo


### PR DESCRIPTION
Haven't looked into actually building/reproducing in this repo yet. Perhaps https://hub.docker.com/r/hseeberger/scala-sbt/tags could be a starting point, but Akka is peculiar in that it needs use jdk11 but also have jdk8 installed.