### PR TITLE
Buildspec dropwizard 2.0.11, 12, 13 include fix for `badDate` in repo history

### DIFF
--- a/content/io/dropwizard/core/dropwizard-2.0.11.buildspec
+++ b/content/io/dropwizard/core/dropwizard-2.0.11.buildspec
@@ -3,7 +3,7 @@ artifactId=dropwizard-core
 display=${groupId}:${artifactId}
 version=2.0.11
 
-gitRepo=https://github.com/dropwizard/dropwizard.git
+gitRepo="-c fetch.fsck.skipList=../gitFsckSkipList https://github.com/dropwizard/dropwizard.git"
 gitTag=v${version}
 
 tool=mvn

--- a/content/io/dropwizard/core/dropwizard-2.0.11.buildspec
+++ b/content/io/dropwizard/core/dropwizard-2.0.11.buildspec
@@ -1,0 +1,14 @@
+groupId=io.dropwizard
+artifactId=dropwizard-core
+display=${groupId}:${artifactId}
+version=2.0.11
+
+gitRepo=https://github.com/dropwizard/dropwizard.git
+gitTag=v${version}
+
+tool=mvn
+jdk=8
+newline=lf
+
+command="mvn clean package -DskipTests"
+buildinfo=dropwizard-archetypes/java-simple/target/java-simple-${version}.buildinfo

--- a/content/io/dropwizard/core/dropwizard-2.0.12.buildspec
+++ b/content/io/dropwizard/core/dropwizard-2.0.12.buildspec
@@ -1,0 +1,14 @@
+groupId=io.dropwizard
+artifactId=dropwizard-core
+display=${groupId}:${artifactId}
+version=2.0.12
+
+gitRepo=https://github.com/dropwizard/dropwizard.git
+gitTag=v${version}
+
+tool=mvn
+jdk=8
+newline=lf
+
+command="mvn clean package -DskipTests"
+buildinfo=dropwizard-archetypes/java-simple/target/java-simple-${version}.buildinfo

--- a/content/io/dropwizard/core/dropwizard-2.0.12.buildspec
+++ b/content/io/dropwizard/core/dropwizard-2.0.12.buildspec
@@ -3,7 +3,7 @@ artifactId=dropwizard-core
 display=${groupId}:${artifactId}
 version=2.0.12
 
-gitRepo=https://github.com/dropwizard/dropwizard.git
+gitRepo="-c fetch.fsck.skipList=../gitFsckSkipList https://github.com/dropwizard/dropwizard.git"
 gitTag=v${version}
 
 tool=mvn

--- a/content/io/dropwizard/core/dropwizard-2.0.13.buildspec
+++ b/content/io/dropwizard/core/dropwizard-2.0.13.buildspec
@@ -1,0 +1,14 @@
+groupId=io.dropwizard
+artifactId=dropwizard-core
+display=${groupId}:${artifactId}
+version=2.0.13
+
+gitRepo="-c fetch.fsck.skipList=../gitFsckSkipList https://github.com/dropwizard/dropwizard.git"
+gitTag=v${version}
+
+tool=mvn
+jdk=8
+newline=lf
+
+command="mvn clean package -DskipTests"
+buildinfo=dropwizard-archetypes/java-simple/target/java-simple-${version}.buildinfo

--- a/content/io/dropwizard/core/gitFsckSkipList
+++ b/content/io/dropwizard/core/gitFsckSkipList
@@ -1,0 +1,1 @@
+6fbf9def0293986beb2547a671f46148a5d2faf7# badDate: invalid author/committer line - bad date

--- a/content/io/dropwizard/core/java-simple-2.0.11.buildinfo.compare
+++ b/content/io/dropwizard/core/java-simple-2.0.11.buildinfo.compare
@@ -1,0 +1,5 @@
+version=2.0.11
+ok=27
+ko=1
+okFiles="dropwizard-util-2.0.11.jar dropwizard-jackson-2.0.11.jar dropwizard-validation-2.0.11.jar dropwizard-configuration-2.0.11.jar dropwizard-logging-2.0.11.jar dropwizard-lifecycle-2.0.11.jar dropwizard-metrics-2.0.11.jar dropwizard-jersey-2.0.11.jar dropwizard-servlets-2.0.11.jar dropwizard-jetty-2.0.11.jar dropwizard-request-logging-2.0.11.jar dropwizard-core-2.0.11.jar dropwizard-testing-2.0.11.jar dropwizard-client-2.0.11.jar dropwizard-db-2.0.11.jar dropwizard-jdbi3-2.0.11.jar dropwizard-migrations-2.0.11.jar dropwizard-hibernate-2.0.11.jar dropwizard-auth-2.0.11.jar dropwizard-forms-2.0.11.jar dropwizard-views-2.0.11.jar dropwizard-views-freemarker-2.0.11.jar dropwizard-views-mustache-2.0.11.jar dropwizard-metrics-graphite-2.0.11.jar dropwizard-assets-2.0.11.jar dropwizard-http2-2.0.11.jar dropwizard-json-logging-2.0.11.jar"
+koFiles="java-simple-2.0.11.jar"

--- a/content/io/dropwizard/core/java-simple-2.0.12.buildinfo.compare
+++ b/content/io/dropwizard/core/java-simple-2.0.12.buildinfo.compare
@@ -1,0 +1,5 @@
+version=2.0.12
+ok=27
+ko=1
+okFiles="dropwizard-util-2.0.12.jar dropwizard-jackson-2.0.12.jar dropwizard-validation-2.0.12.jar dropwizard-configuration-2.0.12.jar dropwizard-logging-2.0.12.jar dropwizard-lifecycle-2.0.12.jar dropwizard-metrics-2.0.12.jar dropwizard-jersey-2.0.12.jar dropwizard-servlets-2.0.12.jar dropwizard-jetty-2.0.12.jar dropwizard-request-logging-2.0.12.jar dropwizard-core-2.0.12.jar dropwizard-testing-2.0.12.jar dropwizard-client-2.0.12.jar dropwizard-db-2.0.12.jar dropwizard-jdbi3-2.0.12.jar dropwizard-migrations-2.0.12.jar dropwizard-hibernate-2.0.12.jar dropwizard-auth-2.0.12.jar dropwizard-forms-2.0.12.jar dropwizard-views-2.0.12.jar dropwizard-views-freemarker-2.0.12.jar dropwizard-views-mustache-2.0.12.jar dropwizard-metrics-graphite-2.0.12.jar dropwizard-assets-2.0.12.jar dropwizard-http2-2.0.12.jar dropwizard-json-logging-2.0.12.jar"
+koFiles="java-simple-2.0.12.jar"

--- a/content/io/dropwizard/core/java-simple-2.0.13.buildinfo.compare
+++ b/content/io/dropwizard/core/java-simple-2.0.13.buildinfo.compare
@@ -1,0 +1,5 @@
+version=2.0.13
+ok=28
+ko=0
+okFiles="dropwizard-util-2.0.13.jar dropwizard-jackson-2.0.13.jar dropwizard-validation-2.0.13.jar dropwizard-configuration-2.0.13.jar dropwizard-logging-2.0.13.jar dropwizard-lifecycle-2.0.13.jar dropwizard-metrics-2.0.13.jar dropwizard-jersey-2.0.13.jar dropwizard-servlets-2.0.13.jar dropwizard-jetty-2.0.13.jar dropwizard-request-logging-2.0.13.jar dropwizard-core-2.0.13.jar dropwizard-testing-2.0.13.jar dropwizard-client-2.0.13.jar dropwizard-db-2.0.13.jar dropwizard-jdbi3-2.0.13.jar dropwizard-migrations-2.0.13.jar dropwizard-hibernate-2.0.13.jar dropwizard-auth-2.0.13.jar dropwizard-forms-2.0.13.jar dropwizard-views-2.0.13.jar dropwizard-views-freemarker-2.0.13.jar dropwizard-views-mustache-2.0.13.jar dropwizard-metrics-graphite-2.0.13.jar dropwizard-assets-2.0.13.jar dropwizard-http2-2.0.13.jar dropwizard-json-logging-2.0.13.jar java-simple-2.0.13.jar"
+koFiles=""


### PR DESCRIPTION
This PR builds on the one from @dialaya: https://github.com/jvm-repo-rebuild/reproducible-central/commit/52568e7593318bb8c36d13fe3602322792aaed99
The `.buildinfo.compare` files in this PR are identical to those in the PR from @dialaya. (versions 2.0.11, 2.0.12).
I added a new `.buildinfo.compare` file for version 2.0.13.

The main difference in my PR is an added fix for a corruption in the history of the origin repo (`badDate`) by telling git `fsck` to skip the corrupted commit.

This corruption will not be visible if you already have the origin repo cloned into your local `buildcache` dir. You would need to delete the `buildcache` dir (and ensure you have not configured git to globally skip fsck objects) in order to see the `badDate` issue.

I used a similar approach in PR #38, so we may want to update the current PR with any improvements from that one. 

Also Fixes #22