### PR TITLE
Add ldapchai 0.7.6 and 0.8.0

### DIFF
--- a/rebuild.sh
+++ b/rebuild.sh
@@ -55,13 +55,19 @@ echo -e "\033[1m$(pwd)\033[0m"
 mvnBuildDocker() {
   local mvnCommand mvnImage
   mvnCommand="$1"
-  # select Docker image to match required JDK version
+  # select Docker image to match required JDK version: https://hub.docker.com/_/maven
   case ${jdk} in
     6 | 7)
       mvnImage=maven:3.6.1-jdk-${jdk}-alpine
       ;;
     9)
       mvnImage=maven:3-jdk-${jdk}-slim
+      ;;
+    14)
+      mvnImage=maven:3.6.3-jdk-${jdk}
+      ;;
+    15)
+      mvnImage=maven:3.6.3-openjdk-${jdk}
       ;;
     *)
       mvnImage=maven:3.6.3-jdk-${jdk}-slim
@@ -108,7 +114,7 @@ rebuildToolMvn() {
   for f in ${buildinfo}*.compare ; do echo -e "rebuilding from \033[1m${buildspec}\033[0m results in \033[1mcat $(dirname ${buildspec})/$(basename $f)\033[0m:"; done
   cat ${buildinfo}*.compare | sed 's/^/    /'
   echo -e "build available in \033[1m$(dirname ${buildspec})/buildcache/${artifactId}\033[0m, where you can execute diffoscope"
-  echo -e "run diffoscope as container with \033[1mdocker run --rm -t -w /mnt -v $(pwd)/${buildspec})/buildcache/${artifactId}:/mnt:ro registry.salsa.debian.org/reproducible-builds/diffoscope\033[0m"
+  echo -e "run diffoscope as container with \033[1mdocker run --rm -t -w /mnt -v $(pwd)/${buildspec}/buildcache/${artifactId}:/mnt:ro registry.salsa.debian.org/reproducible-builds/diffoscope\033[0m"
 }
 
 # rebuild with SBT tool (tool=sbt)

--- a/wip/ldapchai-0.7.6.buildspec
+++ b/wip/ldapchai-0.7.6.buildspec
@@ -1,0 +1,26 @@
+# see instructions https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/BUILDSPEC.md
+
+# Central Repository coordinates for the Reference release
+groupId=com.github.ldapchai
+artifactId=ldapchai
+version=0.7.6
+
+display=${groupId}:${artifactId}
+
+# Source code
+gitRepo=https://github.com/ldapchai/${artifactId}.git
+gitTag=v${version}
+
+# Rebuild environment prerequisites
+tool=mvn
+jdk=14
+newline=lf
+
+# Rebuild command
+command="mvn clean package -DskipJavadoc=true -Dcheckstyle.skip=true -Dmaven.test.skip=true -DskipSpotbugs=true"
+
+# Location of the buildinfo file generated during rebuild to record output fingerprints
+buildinfo=target/${artifactId}-${version}.buildinfo
+
+# if the release is finally not reproducible, link to an issue tracker entry if one was created
+issue=

--- a/wip/ldapchai-0.8.0.buildspec
+++ b/wip/ldapchai-0.8.0.buildspec
@@ -23,4 +23,4 @@ command="mvn clean package -DskipJavadoc=true -Dcheckstyle.skip=true -Dmaven.tes
 buildinfo=target/${artifactId}-${version}.buildinfo
 
 # if the release is finally not reproducible, link to an issue tracker entry if one was created
-issue=
+issue=https://github.com/ldapchai/ldapchai/pull/24

--- a/wip/ldapchai-0.8.0.buildspec
+++ b/wip/ldapchai-0.8.0.buildspec
@@ -1,0 +1,26 @@
+# see instructions https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/BUILDSPEC.md
+
+# Central Repository coordinates for the Reference release
+groupId=com.github.ldapchai
+artifactId=ldapchai
+version=0.8.0
+
+display=${groupId}:${artifactId}
+
+# Source code
+gitRepo=https://github.com/ldapchai/${artifactId}.git
+gitTag=v${version}
+
+# Rebuild environment prerequisites
+tool=mvn
+jdk=15
+newline=lf
+
+# Rebuild command
+command="mvn clean package -DskipJavadoc=true -Dcheckstyle.skip=true -Dmaven.test.skip=true -DskipSpotbugs=true"
+
+# Location of the buildinfo file generated during rebuild to record output fingerprints
+buildinfo=target/${artifactId}-${version}.buildinfo
+
+# if the release is finally not reproducible, link to an issue tracker entry if one was created
+issue=


### PR DESCRIPTION
Tried to reproduce https://repo.maven.apache.org/maven2/com/github/ldapchai/ldapchai/0.7.6/ldapchai-0.7.6.pom (Refs #42)

There are differences in META-INF/MANIFEST.MF, e.g. 

```diff
-Implementation-Build-Java-Vendor: AdoptOpenJDK
-Implementation-Build-Java-Version: 15
+Implementation-Build-Java-Vendor: Oracle Corporation
+Implementation-Build-Java-Version: 15.0.1
```

Should we try to match the exact JVM Vendor+Version when reproducing or should the project rather use "java.specification.version" (which is in this example 15)?

There is one other change:

```diff
-SCM-Git-Branch: master
+SCM-Git-Branch: 338023a44e4dc62aff8985ca42c2f6743258b1c0
```

This probably must be fixed by the project - using "master" here won't work, since when reproducing, master might point already to a later commit. Is this assumption correct?

I would create then an issue/PR upstream...

<details>
  <summary>ldapchai-0.7.6.jar</summary>
  <p>

```diff
--- target/reference/ldapchai-0.7.6.jar
+++ target/ldapchai-0.7.6.jar
├── zipinfo {}
│ @@ -1,9 +1,9 @@
│  Zip file size: 709683 bytes, number of entries: 432
│ --rw-r--r--  2.0 unx      732 b- defN 20-Aug-20 03:44 META-INF/MANIFEST.MF
│ +-rw-r--r--  2.0 unx      772 b- defN 20-Aug-20 03:44 META-INF/MANIFEST.MF
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Aug-20 03:44 META-INF/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Aug-20 03:44 META-INF/source/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Aug-20 03:44 META-INF/source/com/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Aug-20 03:44 META-INF/source/com/novell/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Aug-20 03:44 META-INF/source/com/novell/ldapchai/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Aug-20 03:44 META-INF/source/com/novell/ldapchai/cr/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Aug-20 03:44 META-INF/source/com/novell/ldapchai/cr/bean/
│ @@ -427,8 +427,8 @@
│  -rw-r--r--  2.0 unx     1810 b- defN 20-Aug-20 03:44 com/novell/ldapchai/util/SearchHelper$FilterSequence.class
│  -rw-r--r--  2.0 unx    12002 b- defN 20-Aug-20 03:44 com/novell/ldapchai/util/SearchHelper.class
│  -rw-r--r--  2.0 unx     4917 b- defN 20-Aug-20 03:44 com/novell/ldapchai/util/StringHelper.class
│  -rw-r--r--  2.0 unx     1085 b- defN 20-Aug-20 03:44 com/novell/ldapchai/util/Uint32Charset$Uint32CharsetDecoder.class
│  -rw-r--r--  2.0 unx     1083 b- defN 20-Aug-20 03:44 com/novell/ldapchai/util/Uint32Charset.class
│  -rw-r--r--  2.0 unx    27793 b- defN 20-Aug-20 03:44 META-INF/maven/com.github.ldapchai/ldapchai/pom.xml
│  -rw-r--r--  2.0 unx       62 b- defN 20-Aug-20 03:44 META-INF/maven/com.github.ldapchai/ldapchai/pom.properties
│ -432 files, 1912431 bytes uncompressed, 626851 bytes compressed:  67.2%
│ +432 files, 1912471 bytes uncompressed, 626851 bytes compressed:  67.2%
├── META-INF/MANIFEST.MF
│ @@ -1,20 +1,20 @@
│  Manifest-Version: 1.0
│  Created-By: Maven Jar Plugin 3.2.0
│  Build-Jdk-Spec: 14
│  Main-Class: com.novell.ldapchai.util.MainHandler
│  Archive-Type: jar
│  Archive-UID: 854FF0D1B8B9E20E9476A6658AEF997E0ACB09ED6F9B593E086D2C8FBD8
│   3DBA8
│ -Implementation-Build-Java-Vendor: AdoptOpenJDK
│ +Implementation-Build-Java-Vendor: Oracle Corporation
│  Implementation-Build-Java-Version: 14.0.2
│  Implementation-Title: LDAP Chai Library
│  Implementation-URL: https://github.com/ldapchai/ldapchai
│  Implementation-Vendor: LDAP Chai Project
│  Implementation-Version: 0.7.6
│ -SCM-Git-Branch: master
│ +SCM-Git-Branch: 142831748eaff44477142ac121e34a2f2b94e19d
│  SCM-Git-Commit-Dirty: false
│  SCM-Git-Commit-ID: 142831748eaff44477142ac121e34a2f2b94e19d
│  SCM-Git-Commit-ID-Abbrev: 1428317
│  SCM-Git-Commit-ID-Description: 1428317
│  SCM-Git-Commit-Timestamp: 2020-08-20T03:44:41Z
```

</p>
</details>

<details>
  <summary>ldapchai-0.7.6-sources.jar</summary>
  <p>

```diff
--- target/reference/ldapchai-0.7.6-sources.jar
+++ target/ldapchai-0.7.6-sources.jar
├── zipinfo {}
│ @@ -1,9 +1,9 @@
│ -Zip file size: 587964 bytes, number of entries: 356
│ --rw-r--r--  2.0 unx      581 b- defN 20-Aug-20 03:44 META-INF/MANIFEST.MF
│ +Zip file size: 587963 bytes, number of entries: 356
│ +-rw-r--r--  2.0 unx      621 b- defN 20-Aug-20 03:44 META-INF/MANIFEST.MF
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Aug-20 03:44 META-INF/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Aug-20 03:44 com/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Aug-20 03:44 com/novell/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Aug-20 03:44 com/novell/ldapchai/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Aug-20 03:44 com/novell/ldapchai/cr/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Aug-20 03:44 com/novell/ldapchai/cr/bean/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Aug-20 03:44 com/novell/ldapchai/exception/
│ @@ -351,8 +351,8 @@
│  -rw-r--r--  2.0 unx     4818 b- defN 20-Aug-20 03:44 META-INF/source/com/novell/ldapchai/util/SCryptUtil.java
│  -rw-r--r--  2.0 unx    22078 b- defN 20-Aug-20 03:44 META-INF/source/com/novell/ldapchai/util/SearchHelper.java
│  -rw-r--r--  2.0 unx     6547 b- defN 20-Aug-20 03:44 META-INF/source/com/novell/ldapchai/util/StringHelper.java
│  -rw-r--r--  2.0 unx     2074 b- defN 20-Aug-20 03:44 META-INF/source/com/novell/ldapchai/util/Uint32Charset.java
│  -rw-r--r--  2.0 unx      932 b- defN 20-Aug-20 03:44 META-INF/source/com/novell/ldapchai/util/package-info.java
│  -rw-r--r--  2.0 unx    27793 b- defN 20-Aug-20 03:44 META-INF/maven/com.github.ldapchai/ldapchai/pom.xml
│  -rw-r--r--  2.0 unx       62 b- defN 20-Aug-20 03:44 META-INF/maven/com.github.ldapchai/ldapchai/pom.properties
│ -356 files, 2080648 bytes uncompressed, 521210 bytes compressed:  75.0%
│ +356 files, 2080688 bytes uncompressed, 521209 bytes compressed:  75.0%
├── META-INF/MANIFEST.MF
│ @@ -1,16 +1,16 @@
│  Manifest-Version: 1.0
│  Created-By: Maven Source Plugin 3.2.1
│  Archive-Type: source
│ -Implementation-Build-Java-Vendor: AdoptOpenJDK
│ +Implementation-Build-Java-Vendor: Oracle Corporation
│  Implementation-Build-Java-Version: 14.0.2
│  Implementation-Title: LDAP Chai Library
│  Implementation-URL: https://github.com/ldapchai/ldapchai
│  Implementation-Vendor: LDAP Chai Project
│  Implementation-Version: 0.7.6
│ -SCM-Git-Branch: master
│ +SCM-Git-Branch: 142831748eaff44477142ac121e34a2f2b94e19d
│  SCM-Git-Commit-Dirty: 
│  SCM-Git-Commit-ID: 142831748eaff44477142ac121e34a2f2b94e19d
│  SCM-Git-Commit-ID-Abbrev: 1428317
│  SCM-Git-Commit-ID-Description: 1428317
│  SCM-Git-Commit-Timestamp: 2020-08-20T03:44:41Z
```

</p>
</details>

<details>
  <summary>ldapchai-0.8.0.jar</summary>
  <p>

```diff
--- target/reference/ldapchai-0.8.0.jar
+++ target/ldapchai-0.8.0.jar
├── zipinfo {}
│ @@ -1,9 +1,9 @@
│ -Zip file size: 711369 bytes, number of entries: 432
│ --rw-r--r--  2.0 unx      728 b- defN 20-Oct-13 14:19 META-INF/MANIFEST.MF
│ +Zip file size: 711372 bytes, number of entries: 432
│ +-rw-r--r--  2.0 unx      772 b- defN 20-Oct-13 14:19 META-INF/MANIFEST.MF
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Oct-13 14:19 META-INF/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Oct-13 14:19 META-INF/source/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Oct-13 14:19 META-INF/source/com/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Oct-13 14:19 META-INF/source/com/novell/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Oct-13 14:19 META-INF/source/com/novell/ldapchai/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Oct-13 14:19 META-INF/source/com/novell/ldapchai/cr/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Oct-13 14:19 META-INF/source/com/novell/ldapchai/cr/bean/
│ @@ -427,8 +427,8 @@
│  -rw-r--r--  2.0 unx     1810 b- defN 20-Oct-13 14:19 com/novell/ldapchai/util/SearchHelper$FilterSequence.class
│  -rw-r--r--  2.0 unx    12002 b- defN 20-Oct-13 14:19 com/novell/ldapchai/util/SearchHelper.class
│  -rw-r--r--  2.0 unx     4917 b- defN 20-Oct-13 14:19 com/novell/ldapchai/util/StringHelper.class
│  -rw-r--r--  2.0 unx     1085 b- defN 20-Oct-13 14:19 com/novell/ldapchai/util/Uint32Charset$Uint32CharsetDecoder.class
│  -rw-r--r--  2.0 unx     1083 b- defN 20-Oct-13 14:19 com/novell/ldapchai/util/Uint32Charset.class
│  -rw-r--r--  2.0 unx    27659 b- defN 20-Oct-13 14:19 META-INF/maven/com.github.ldapchai/ldapchai/pom.xml
│  -rw-r--r--  2.0 unx       62 b- defN 20-Oct-13 14:19 META-INF/maven/com.github.ldapchai/ldapchai/pom.properties
│ -432 files, 1916712 bytes uncompressed, 628537 bytes compressed:  67.2%
│ +432 files, 1916756 bytes uncompressed, 628540 bytes compressed:  67.2%
├── META-INF/MANIFEST.MF
│ @@ -1,20 +1,20 @@
│  Manifest-Version: 1.0
│  Created-By: Maven Jar Plugin 3.2.0
│  Build-Jdk-Spec: 15
│  Main-Class: com.novell.ldapchai.util.MainHandler
│  Archive-Type: jar
│  Archive-UID: 854FF0D1B8B9E20E9476A6658AEF997E0ACB09ED6F9B593E086D2C8FBD8
│   3DBA8
│ -Implementation-Build-Java-Vendor: AdoptOpenJDK
│ -Implementation-Build-Java-Version: 15
│ +Implementation-Build-Java-Vendor: Oracle Corporation
│ +Implementation-Build-Java-Version: 15.0.1
│  Implementation-Title: LDAP Chai Library
│  Implementation-URL: https://github.com/ldapchai/ldapchai
│  Implementation-Vendor: LDAP Chai Project
│  Implementation-Version: 0.8.0
│ -SCM-Git-Branch: master
│ +SCM-Git-Branch: 338023a44e4dc62aff8985ca42c2f6743258b1c0
│  SCM-Git-Commit-Dirty: false
│  SCM-Git-Commit-ID: 338023a44e4dc62aff8985ca42c2f6743258b1c0
│  SCM-Git-Commit-ID-Abbrev: 338023a
│  SCM-Git-Commit-ID-Description: 338023a
│  SCM-Git-Commit-Timestamp: 2020-10-13T14:19:10Z
```

</p>
</details>

<details>
  <summary>ldapchai-0.8.0-sources.jar</summary>
  <p>

```diff
--- target/reference/ldapchai-0.8.0-sources.jar
+++ target/ldapchai-0.8.0-sources.jar
├── zipinfo {}
│ @@ -1,9 +1,9 @@
│ -Zip file size: 588973 bytes, number of entries: 356
│ --rw-r--r--  2.0 unx      577 b- defN 20-Oct-13 14:19 META-INF/MANIFEST.MF
│ +Zip file size: 588975 bytes, number of entries: 356
│ +-rw-r--r--  2.0 unx      621 b- defN 20-Oct-13 14:19 META-INF/MANIFEST.MF
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Oct-13 14:19 META-INF/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Oct-13 14:19 com/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Oct-13 14:19 com/novell/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Oct-13 14:19 com/novell/ldapchai/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Oct-13 14:19 com/novell/ldapchai/cr/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Oct-13 14:19 com/novell/ldapchai/cr/bean/
│  drwxr-xr-x  2.0 unx        0 b- stor 20-Oct-13 14:19 com/novell/ldapchai/exception/
│ @@ -351,8 +351,8 @@
│  -rw-r--r--  2.0 unx     4818 b- defN 20-Oct-13 14:19 META-INF/source/com/novell/ldapchai/util/SCryptUtil.java
│  -rw-r--r--  2.0 unx    22078 b- defN 20-Oct-13 14:19 META-INF/source/com/novell/ldapchai/util/SearchHelper.java
│  -rw-r--r--  2.0 unx     6547 b- defN 20-Oct-13 14:19 META-INF/source/com/novell/ldapchai/util/StringHelper.java
│  -rw-r--r--  2.0 unx     2074 b- defN 20-Oct-13 14:19 META-INF/source/com/novell/ldapchai/util/Uint32Charset.java
│  -rw-r--r--  2.0 unx      932 b- defN 20-Oct-13 14:19 META-INF/source/com/novell/ldapchai/util/package-info.java
│  -rw-r--r--  2.0 unx    27659 b- defN 20-Oct-13 14:19 META-INF/maven/com.github.ldapchai/ldapchai/pom.xml
│  -rw-r--r--  2.0 unx       62 b- defN 20-Oct-13 14:19 META-INF/maven/com.github.ldapchai/ldapchai/pom.properties
│ -356 files, 2083200 bytes uncompressed, 522219 bytes compressed:  74.9%
│ +356 files, 2083244 bytes uncompressed, 522221 bytes compressed:  74.9%
├── META-INF/MANIFEST.MF
│ @@ -1,16 +1,16 @@
│  Manifest-Version: 1.0
│  Created-By: Maven Source Plugin 3.2.1
│  Archive-Type: source
│ -Implementation-Build-Java-Vendor: AdoptOpenJDK
│ -Implementation-Build-Java-Version: 15
│ +Implementation-Build-Java-Vendor: Oracle Corporation
│ +Implementation-Build-Java-Version: 15.0.1
│  Implementation-Title: LDAP Chai Library
│  Implementation-URL: https://github.com/ldapchai/ldapchai
│  Implementation-Vendor: LDAP Chai Project
│  Implementation-Version: 0.8.0
│ -SCM-Git-Branch: master
│ +SCM-Git-Branch: 338023a44e4dc62aff8985ca42c2f6743258b1c0
│  SCM-Git-Commit-Dirty: 
│  SCM-Git-Commit-ID: 338023a44e4dc62aff8985ca42c2f6743258b1c0
│  SCM-Git-Commit-ID-Abbrev: 338023a
│  SCM-Git-Commit-ID-Description: 338023a
│  SCM-Git-Commit-Timestamp: 2020-10-13T14:19:10Z
```
