### PR TITLE
Add quick-perf-1.0.0

### DIFF
--- a/wip/quick-perf-1.0.0.buildspec
+++ b/wip/quick-perf-1.0.0.buildspec
@@ -1,9 +1,10 @@
 # see instructions https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/BUILDSPEC.md
+# see instructions https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/BUILDSPEC.md
 
 # Central Repository coordinates for the Reference release
 groupId=org.quickperf
 artifactId=quick-perf
-version=1.0.0-RC7
+version=1.0.0
 
 display=${groupId}:${artifactId}
 
@@ -23,4 +24,4 @@ command="mvn clean package -DskipTests -Dmaven.javadoc.skip -Dgpg.skip"
 buildinfo=bom/target/quick-perf-bom-${version}.buildinfo
 
 # if the release is finally not reproducible, link to an issue tracker entry if one was created
-issue=https://github.com/quick-perf/quickperf/issues/126
+issue=


### PR DESCRIPTION
First try fails 😭:
```sh
./rebuild.sh ./wip/quick-perf-1.0.0.buildspec

# ✂--------
rebuilding from ./wip/quick-perf-1.0.0.buildspec results in cat ./wip/quick-perf-bom-1.0.0.buildinfo.compare:
    version=1.0.0
    ok=0
    ko=15
    okFiles=""
    koFiles="quick-perf-core-1.0.0.jar quick-perf-jvm-core-1.0.0.jar quick-perf-jvm-annotations-1.0.0.jar quick-perf-jfr-annotations-1.0.0.jar quick-perf-sql-annotations-1.0.0.jar quick-perf-junit4-1.0.0.jar quick-perf-junit5-1.0.0.jar quick-perf-testng-1.0.0.jar quick-perf-sql-spring4-1.0.0.jar quick-perf-sql-spring5-1.0.0.jar quick-perf-junit4-spring3-1.0.0.jar quick-perf-junit4-spring4-1.0.0.jar quick-perf-junit4-spring5-1.0.0.jar quick-perf-springboot1-sql-starter-1.0.0.jar quick-perf-springboot2-sql-starter-1.0.0.jar"
build available in ./wip/buildcache/quick-perf, where you can execute diffoscope
run diffoscope as container with docker run --rm -t -w /mnt -v /Users/nicolas/work/reproducible-central/wip/buildcache/quick-perf/./wip/quick-perf-1.0.0.buildspec/buildcache/quick-perf:/mnt:ro registry.salsa.debian.org/reproducible-builds/diffoscope
```

Full logs:
[quick-perf-1.0.0.log](https://github.com/jvm-repo-rebuild/reproducible-central/files/5610910/quick-perf-1.0.0.log)


