### PR TITLE
improve colors of project badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ between reference file from Central Repository and effective rebuild file, then 
 
 <details><summary><b>Add Reproducible Builds Badge to a Project With Reproducible Releases</b></summary>
 
-If a project has listed here at least one release with proven reproducibility success, it can add a badge like ![Reproducible Builds](https://img.shields.io/badge/Reproducible_Builds-ok-green?labelColor=blue) pointing to its entries here:
+If a project has listed here at least one release with proven reproducibility success, it can add a badge like ![Reproducible Builds](https://img.shields.io/badge/Reproducible_Builds-ok-success?labelColor=1e5b96) pointing to its entries here:
 
 ```
-[![Reproducible Builds](https://img.shields.io/badge/Reproducible_Builds-ok-green?labelColor=blue)](https://github.com/jvm-repo-rebuild/reproducible-central#...groupId...:...artifactId...)
+[![Reproducible Builds](https://img.shields.io/badge/Reproducible_Builds-ok-success?labelColor=1e5b96)](https://github.com/jvm-repo-rebuild/reproducible-central#...groupId...:...artifactId...)
 ```
 
 Notice the anchor in the link.


### PR DESCRIPTION
Use a darker blue for the left side, matching the dark blue of the [reproducible-builds.org](https://reproducible-builds.org/) logo.

Use a different green for the right side, matching the standard green used for other "success" badges from <https://shields.io/>, such as for continuous integration, dependency updates, and license checks.

| Before | After
|--|--
| [![Reproducible Builds](https://img.shields.io/badge/Reproducible_Builds-ok-green?labelColor=blue)](https://reproducible-builds.org/) | [![Reproducible Builds](https://img.shields.io/badge/Reproducible_Builds-ok-success?labelColor=1e5b96)](https://reproducible-builds.org/)

I've adopted this in <https://github.com/qunitjs/qunit#readme> as example.