### PR TITLE
document requirement for gsed on mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,17 @@ equivalent to the packaging instructions that are maintained by every Linux dist
     * `dos2unix` - DOS to MAC/UNIX text file format converter. 
       
       Can be installed via [homebrew](https://brew.sh) on MAC via: `brew install dos2unix`.
+ 
+    * `gsed` - on mac, to provide gnu sed command. 
+      
+      Can be installed via [homebrew](https://brew.sh) on MAC via: `brew install gsed`.
+ 
+      If you are missing `gsed` on a MAC, you may see an error like the one below:
+          
+          ...
+          dos2unix: converting file target/maven-shared-utils-3.3.4.buildinfo to Unix format...
+          dos2unix: converting file target/maven-shared-utils-3.3.4.buildinfo.compare to Unix format...
+          ./rebuild.sh: line 143: gsed: command not found
    </details>
 
 You can rebuild a project release by running:

--- a/README.md
+++ b/README.md
@@ -20,17 +20,6 @@ equivalent to the packaging instructions that are maintained by every Linux dist
     * `dos2unix` - DOS to MAC/UNIX text file format converter. 
       
       Can be installed via [homebrew](https://brew.sh) on MAC via: `brew install dos2unix`.
- 
-    * `gsed` - on mac, to provide gnu sed command. 
-      
-      Can be installed via [homebrew](https://brew.sh) on MAC via: `brew install gsed`.
- 
-      If you are missing `gsed` on a MAC, you may see an error like the one below:
-          
-          ...
-          dos2unix: converting file target/maven-shared-utils-3.3.4.buildinfo to Unix format...
-          dos2unix: converting file target/maven-shared-utils-3.3.4.buildinfo.compare to Unix format...
-          ./rebuild.sh: line 143: gsed: command not found
    </details>
 
 You can rebuild a project release by running:

--- a/build_diffoscope.sh
+++ b/build_diffoscope.sh
@@ -10,6 +10,7 @@ echo -e "saving build diffoscope file to \033[1m${diffoscope_file}\033[0m"
 set sed="sed"
 if [ "$(uname -s)" ==  "Darwin" ]
 then
+  command -v gsed >/dev/null 2>&1 || { echo "require GNU sed: brew install gsed  Aborting."; exit 1; }
   sed="gsed"
 fi
 

--- a/build_diffoscope.sh
+++ b/build_diffoscope.sh
@@ -7,7 +7,13 @@ diffoscope_file=$(dirname ${compare})/$(basename ${compare} .buildinfo.compare).
 
 echo -e "saving build diffoscope file to \033[1m${diffoscope_file}\033[0m"
 
-grep '# diffoscope ' ${compare} | sed -e 's/# diffoscope //' | ( while read -r line
+set sed="sed"
+if [ "$(uname -s)" ==  "Darwin" ]
+then
+  sed="gsed"
+fi
+
+grep '# diffoscope ' ${compare} | ${sed} -e 's/# diffoscope //' | ( while read -r line
 do
   echo -e "\033[1m$line\033[0m"
   docker run --rm -t -w /mnt -v $(pwd)/$(dirname ${compare})/${builddir}:/mnt:ro registry.salsa.debian.org/reproducible-builds/diffoscope --no-progress $line
@@ -15,7 +21,7 @@ do
 done ) | tee ${diffoscope_file}
 
 # remove ansi escape codes from file
-sed -i 's/\x1b\[[0-9;]*m//g' ${diffoscope_file}
+${sed} -i 's/\x1b\[[0-9;]*m//g' ${diffoscope_file}
 
 echo -e "build diffoscope file saved to \033[1m${diffoscope_file}\033[0m"
 du -h ${diffoscope_file}


### PR DESCRIPTION
still testing to make sure the documented solution solves the problem, but looks correct so far.

Also starting to feel like  the "Prerequisites" section to move up to being a top level bullet, as I think it applies to all subsequent bullets.

Piling on: I saw this error when running the `build_diffoscope.sh` command: 
```
sed: ip/maven-shared-utils-3.3.4.diffoscope: No such file or directory
```
I'm guessing it is because the default `sed` is not gnu. I tried to steal what you did in the other script. 