### PR TITLE
Fix Error on build_diffoscope.sh: command not found 

### DIFF
--- a/build_diffoscope.sh
+++ b/build_diffoscope.sh
@@ -7,7 +7,7 @@ diffoscope_file=$(dirname ${compare})/$(basename ${compare} .buildinfo.compare).
 
 echo -e "saving build diffoscope file to \033[1m${diffoscope_file}\033[0m"
 
-set sed="sed"
+sed="sed"
 if [ "$(uname -s)" ==  "Darwin" ]
 then
   command -v gsed >/dev/null 2>&1 || { echo "require GNU sed: brew install gsed  Aborting."; exit 1; }


### PR DESCRIPTION
I have updated to the latest version. But i get an error when i run this command:
```
./build_diffoscope.sh content/com/taobao/arthas/arthas-all-3.5.1.buildinfo.compare buildcache/arthas-all
```
The error:
```
./build_diffoscope.sh: line 17: -e: command not found
./build_diffoscope.sh: line 25: -i: command not found
```
I am using Ubuntu 20.04.