### PR TITLE
Fix a syntax error in sample .buildspec

### DIFF
--- a/BUILDSPEC.md
+++ b/BUILDSPEC.md
@@ -24,7 +24,7 @@ gitTag=${artifactId}-${version}
 # or use source zip archive
 sourceDistribution=https://archive.apache.org/dist/maven/scm/${artifactId}-${version}-source-release.zip
 sourcePath=${artifactId}-${version}
-sourceRmFiles=DEPENDENCIES LICENSE NOTICE
+sourceRmFiles="DEPENDENCIES LICENSE NOTICE"
 
 # Rebuild environment prerequisites
 tool=mvn


### PR DESCRIPTION
This would throw here: https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/rebuild.sh#L22

```
$ sourceRmFiles=DEPENDENCIES LICENSE NOTICE
bash: LICENSE: command not found
```