### PR TITLE
Podman engine support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,5 @@ settings-docker.xml
 
 doc/buildspecs.txt
 
+# IDE local folders
+.idea/

--- a/doc/TOOLS.md
+++ b/doc/TOOLS.md
@@ -15,7 +15,7 @@ If you want to start playing with the reproducible builds, we recommend the foll
 
 Prerequisites:
     
-    * [Docker](https://www.docker.com)
+    * [Docker](https://www.docker.com) or [podman](https://podman.io/)
     
     * `dos2unix` - DOS to MAC/UNIX text file format converter. 
       
@@ -25,6 +25,12 @@ You can rebuild a project release by running:
 ```
 ./rebuild.sh content/<path/to/...>/<project>-<version>.buildspec
 ```
+
+In case you would like to use podman as a container engine, you can use the following command:
+```
+./rebuild.sh content/<path/to/...>/<project>-<version>.buildspec podman
+```
+
 [`rebuild.sh` script](./rebuild.sh) will use the build specification file (= [`.buildspec` file](BUILDSPEC.md)) to choose a Docker image to rebuild the project and check output against Central Repository reference binaries.
 
 For example:

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -86,15 +86,6 @@ fi
 
 echo -e "\033[1m$(pwd)\033[0m"
 
-containerEngine() {
-  if [[ ${container_engine} == "podman" ]]
-  then
-    podman "$1"
-  else
-    docker "$1"
-  fi
-}
-
 mvnBuildDocker() {
   local mvnCommand mvnImage crlfDocker mvnVersion
   mvnCommand="$1"
@@ -131,11 +122,11 @@ mvnBuildDocker() {
     *)
       mvnImage=maven:${mvnVersion}-eclipse-temurin-${jdk}-alpine
   esac
-  if ! containerEngine pull -q ${mvnImage} > /dev/null 2>&1
+  if ! ${container_engine} pull -q ${mvnImage} > /dev/null 2>&1
   then
     for image in maven:{${mvnVersion},3}-eclipse-temurin-${jdk}-alpine
     do
-      if containerEngine pull -q ${image} > /dev/null 2>&1
+      if ${container_engine} pull -q ${image} > /dev/null 2>&1
       then
         mvnImage=${image}
         break


### PR DESCRIPTION
Hi :wave: 

Thank you for this repository and your work on reproducible builds. I'm proposing this change to enable a podman support as a container engine instead of docker. It might help users to work on this project by providing an alternative for a container engine.

This change has been made as a non-blocking change. Existing commands are expected to still use docker as a default, without any change.

The flexibility has been added with an allow list in mind to prevent users specifying an unplanned and untested alternative. This is performed in ` rebuild.sh` through the `container_engine` variable and the `containerEngine()` function, introduced by this PR.

I worked on this change to be minimal. If you would prefer a more robust change with a named parameter, do not hesitate to let me know. Your comments are welcomed, thank you for your help :slightly_smiling_face: 