### PR TITLE
fix the move command in rebuild.sh

### DIFF
--- a/rebuild.sh
+++ b/rebuild.sh
@@ -243,7 +243,7 @@ displayResult() {
 
   if [[ ${buildspec} == wip/* ]]
   then
-    echo -e "\033[93mWork In Progress\033[0m: once work ready to publish, move to target directory with \033[1mdir=content/$(echo ${groupId} | tr '.' '/')/${artifactId} ; mkdir -p \${dir} ; mv ${buildspec} wip/$(basename ${buildinfo} .buildinfo).build* \${dir} \033[0m"
+    echo -e "\033[93mWork In Progress\033[0m: once work is ready to be published, move it to target directory with \033[1mdir=content/$(echo ${groupId} | tr '.' '/')/${artifactId} ; mkdir -p \${dir} ; mv wip/$(basename ${buildinfo} .buildinfo).build* \${dir} \033[0m"
   fi
 }
 


### PR DESCRIPTION
Removing `${buildinfo}` from the move commande : `wip/$(basename ${buildinfo} .buildinfo).build*` is already matching all the files.