### PR TITLE
Map a volume for user.home working directory

### DIFF
--- a/bin/includes/rebuildToolGradle.sh
+++ b/bin/includes/rebuildToolGradle.sh
@@ -35,6 +35,7 @@ rebuildToolGradle() {
 
   local docker_command="docker run -it --rm --name rebuild-central\
     -v $PWD:/var/gradle/app\
+    -v $PWD/userhome:/home/gradle\
     -v $PWD:/home/gradle/.m2\
     -v $base/.sbt:/home/gradle/.sbt\
     -v $base/.bnd:/.bnd\


### PR DESCRIPTION
/home/gradle must be mounted as a volume

Fixes #142

Error reported on macOs when running  jreleaser-1.11.0

```
/home/gradle/.gitconfig
java.nio.file.AccessDeniedException: /home/gradle/.gitconfig
        at java.base/sun.nio.fs.UnixException.translateToIOException(UnixException.java:90)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:106)
        at java.base/sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:111)
        at java.base/sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
        at java.base/sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:148)
        at java.base/sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:99)
        at java.base/java.nio.file.Files.readAttributes(Files.java:1851)
        at org.eclipse.jgit.util.FileUtils.fileAttributes(FileUtils.java:710)
```