### PR TITLE
Create branch before pushing

### DIFF
--- a/bin/includes/displayResult.sh
+++ b/bin/includes/displayResult.sh
@@ -48,6 +48,6 @@ displayResult() {
   then
     echo -e "\033[93mWork In Progress\033[0m: once work is ready to be published, move it to target directory with:"
     echo -e "                  \033[1mdir=content/$(echo ${groupId} | tr '.' '/')/${artifactId} ; mkdir -p \${dir} ; mv wip/maven-metadata.xml wip/$(basename ${buildinfo} .buildinfo).* \${dir} \033[0m"
-    echo -e "                  \033[1mgit add \${dir} ; git commit -m \"add $(basename ${buildinfo} .buildinfo)\" ; git push\033[0m"
+    echo -e "                  \033[1mgit checkout -b $(basename ${groupId}-${artifactId}) ; git add \${dir} ; git commit -m \"add $(basename ${buildinfo} .buildinfo)\" ; git push\033[0m"
   fi
 }


### PR DESCRIPTION
The change proposed creates a branch before pushing, to prevent pushing directly to the default branch, when creating a PR.

![Screenshot 2024-04-21 at 13 00 58](https://github.com/jvm-repo-rebuild/reproducible-central/assets/13383509/1936dea3-dcee-4a80-ad03-b46c134542c2)