### PR TITLE
Add podman support for Gradle builds

### DIFF
--- a/bin/includes/rebuildToolGradle.sh
+++ b/bin/includes/rebuildToolGradle.sh
@@ -26,9 +26,9 @@ rebuildToolGradle() {
 #      jdkImage="openjdk:17-slim"
 #      ;;
 #  esac
-  jdkImage="gradle:8-jdk${jdk}"
+  jdkImage="docker.io/library/gradle:8-jdk${jdk}"
 
-  info "Rebuilding using Docker image ${jdkImage}"
+  info "Rebuilding using image ${jdkImage}"
 
   local OUTPUTDIR=repository
   [ -d ${OUTPUTDIR} ] && \rm -rf ${OUTPUTDIR}
@@ -36,17 +36,19 @@ rebuildToolGradle() {
   [ -d userhome/.gradle ] || mkdir -p userhome/.gradle
   find . -name build -exec \rm -rf {} \;
 
-  local docker_command="docker run -it --rm --name rebuild-central\
-    -v $PWD:/var/gradle/app\
-    -v $PWD/userhome:/home/gradle\
-    -v $PWD:/home/gradle/.m2\
-    -v $base/.gradle:/home/gradle/.gradle\
+  local engine_command="$REBUILD_ENGINE run -it --rm --name rebuild-central\
+    ${REBUILD_ENGINE_OPTS}\
+    -v $PWD:/var/gradle/app${REBUILD_VOLUME_FLAGS}\
+    -v $PWD/userhome:/home/gradle${REBUILD_VOLUME_FLAGS}\
+    -v $PWD:/home/gradle/.m2${REBUILD_VOLUME_FLAGS}\
+    -v $PWD/userhome/.gradle:/home/gradle/.gradle${REBUILD_VOLUME_FLAGS}\
     -u $(id -u ${USER}):$(id -g ${USER})\
     -e MAVEN_CONFIG=/home/gradle/.m2\
+    -e GRADLE_USER_HOME=/home/gradle/.gradle\
     -w /var/gradle/app"
-  local gradle_docker_params="-Duser.home=/home/gradle"
+  local gradle_engine_params="-Duser.home=/home/gradle"
 
-  runcommand ${docker_command} ${jdkImage} ${command} ${gradle_docker_params}
+  runcommand ${engine_command} ${jdkImage} ${command} ${gradle_engine_params}
   
   if [ $? -eq 0 ]; then
       # output content is expected to be available in repository/ directory

--- a/doc/TOOLS.md
+++ b/doc/TOOLS.md
@@ -14,7 +14,7 @@ If you want to start playing with the reproducible builds, we recommend the foll
 ### 1) Rebuild Yourself To Check Results
 
 Prerequisites:
-* [Docker](https://www.docker.com)
+* [Docker](https://www.docker.com) or [Podman](https://podman.io)
 * `dos2unix` - DOS to MAC/UNIX text file format converter. \
    Can be installed via [homebrew](https://brew.sh) on MAC via: `brew install dos2unix`.
 
@@ -24,10 +24,23 @@ You can rebuild a project release by running:
 ```
 [`rebuild.sh` script](./rebuild.sh) will use the build specification file (= [`.buildspec` file](BUILDSPEC.md)) to choose a Docker image to rebuild the project and check output against Central Repository reference binaries.
 
+
 For example:
 ```
 ./rebuild.sh content/org/apache/maven/shared/archiver/maven-archiver-3.5.1.buildspec
 ```
+
+You can also use `podman` as a container engine by defining the environment variables before you run `rebuild.sh`:
+
+	REBUILD_ENGINE
+	# The engine to use. Defaults to 'docker', but also tested with 'podman'.
+
+	REBUILD_ENGINE_OPTS
+	# Extra options to provide to the container engine. Defaults to docker: "", podman: "--userns=keep-id"
+	
+	REBUILD_VOLUME_FLAGS
+	# Extra flags to use when mounting volumes in the container. Defaults to "", but for podman running on an SELinux host, you need ":Z,rw"
+
 
 ### 2) Contribute to a new _buildspec_
 

--- a/doc/TOOLS.md
+++ b/doc/TOOLS.md
@@ -30,16 +30,16 @@ For example:
 ./rebuild.sh content/org/apache/maven/shared/archiver/maven-archiver-3.5.1.buildspec
 ```
 
-You can also use `podman` as a container engine by defining the environment variables before you run `rebuild.sh`:
+You can also use `podman` as a container engine by defining these environment variables before you run `rebuild.sh`:
 
-	REBUILD_ENGINE
 	# The engine to use. Defaults to 'docker', but also tested with 'podman'.
+	REBUILD_ENGINE
 
-	REBUILD_ENGINE_OPTS
 	# Extra options to provide to the container engine. Defaults to docker: "", podman: "--userns=keep-id"
+	REBUILD_ENGINE_OPTS
 	
-	REBUILD_VOLUME_FLAGS
 	# Extra flags to use when mounting volumes in the container. Defaults to "", but for podman running on an SELinux host, you need ":Z,rw"
+	REBUILD_VOLUME_FLAGS
 
 
 ### 2) Contribute to a new _buildspec_

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -87,6 +87,25 @@ umask $umask
 export MVN_UMASK=${umask}
 fetchSource
 
+DEFAULT_engine="docker"
+DEFAULT_engineopts_docker=""
+DEFAULT_engineopts_podman="--userns=keep-id"
+DEFAULT_engineopts="$([[ 'docker' == ${REBUILD_ENGINE:-$DEFAULT_engine} ]] && echo $DEFAULT_engineopts_docker || echo $DEFAULT_engineopts_podman)"
+DEFAULT_volumeflags=""
+
+if [ -z "${REBUILD_ENGINE}" ]
+then
+  export REBUILD_ENGINE=$DEFAULT_engine
+fi
+if [ -z "${REBUILD_ENGINE_OPTS}" ]
+then
+  export REBUILD_ENGINE_OPTS=$DEFAULT_engineopts
+fi
+if [ -z "${REBUILD_VOLUME_FLAGS}" ]
+then
+  export REBUILD_VOLUME_FLAGS=$DEFAULT_volumeflags;
+fi
+
 echo
 case ${tool} in
   mvn*)


### PR DESCRIPTION
Hi there!

I run a Fedora system with SELinux enabled, and use Podman as a container engine.

So I have changed the rebuild and gradle scripts to allow using podman.

While I can reproduce the build for:

```console
REBUILD_ENGINE=podman REBUILD_VOLUME_FLAGS=":Z,rw" ./rebuild.sh content/org/mockito/mockito-core/mockito-5.8.0.buildspec
```

I am unsure if the changes might have broken the docker (gradle) support?

In particular, there may be some trouble around the mounting of .gradle.
Not sure why it was mounted as it was before? The folder did not exist.
Instead I mount the location of the folder created above (similar to .m2).
