### PR TITLE
Adds support for using Podman instead of Docker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,9 @@ settings-docker.xml
 .idea
 *.iml
 
+# Eclipse
+.project
+
 # ci config for local ci build
 .circleci/local-config.yml
 

--- a/bin/docker/Dockerfile.toolchains.template
+++ b/bin/docker/Dockerfile.toolchains.template
@@ -11,7 +11,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM ubuntu:22.04
+FROM docker.io/library/ubuntu:22.04
 
 ENV INSIDE_DOCKER Yes
 

--- a/doc/TOOLS.md
+++ b/doc/TOOLS.md
@@ -14,7 +14,7 @@ If you want to start playing with the reproducible builds, we recommend the foll
 ### 1) Rebuild Yourself To Check Results
 
 Prerequisites:
-* [Docker](https://www.docker.com)
+* [Docker](https://www.docker.com) or [Podman](https://podman.io)
 * `dos2unix` - DOS to MAC/UNIX text file format converter. \
    Can be installed via [homebrew](https://brew.sh) on MAC via: `brew install dos2unix`.
 
@@ -24,10 +24,26 @@ You can rebuild a project release by running:
 ```
 [`rebuild.sh` script](./rebuild.sh) will use the build specification file (= [`.buildspec` file](BUILDSPEC.md)) to choose a Docker image to rebuild the project and check output against Central Repository reference binaries.
 
+
 For example:
 ```
 ./rebuild.sh content/org/apache/maven/shared/archiver/maven-archiver-3.5.1.buildspec
 ```
+
+You can also use `podman` as a container engine by defining these environment variables before you run `rebuild.sh`:
+
+    # The engine to use. Defaults to 'docker', but also tested with 'podman'.
+    RB_OCI_ENGINE
+    
+    # Extra build-options to provide to the container engine. Defaults for docker: "", podman: "--format docker"
+    RB_OCI_ENGINE_BUILD_OPTS
+    
+    # Extra run-options to provide to the container engine. Defaults for docker: "", podman: "--userns=keep-id"
+    RB_OCI_ENGINE_RUN_OPTS
+    
+    # Extra flags to use when mounting volumes in the container. Defaults to "", but for podman running on an SELinux host, you need ":Z,rw"
+    RB_OCI_VOLUME_FLAGS
+
 
 ### 2) Contribute to a new _buildspec_
 

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -87,6 +87,32 @@ umask $umask
 export MVN_UMASK=${umask}
 fetchSource
 
+DEFAULT_engine="docker"
+DEFAULT_engine_buildopts_docker=""
+DEFAULT_engine_buildopts_podman="--format docker"
+DEFAULT_engine_buildopts="$([[ 'docker' == ${RB_OCI_ENGINE:-$DEFAULT_engine} ]] && echo $DEFAULT_engine_buildopts_docker || echo $DEFAULT_engine_buildopts_podman)"
+DEFAULT_engine_runopts_docker=""
+DEFAULT_engine_runopts_podman="--userns=keep-id"
+DEFAULT_engine_runopts="$([[ 'docker' == ${RB_OCI_ENGINE:-$DEFAULT_engine} ]] && echo $DEFAULT_engine_runopts_docker || echo $DEFAULT_engine_runopts_podman)"
+DEFAULT_volumeflags=""
+
+if [ -z "${RB_OCI_ENGINE}" ]
+then
+  export RB_OCI_ENGINE=$DEFAULT_engine
+fi
+if [ -z "${RB_OCI_ENGINE_BUILD_OPTS}" ]
+then
+  export RB_OCI_ENGINE_BUILD_OPTS=$DEFAULT_engine_buildopts
+fi
+if [ -z "${RB_OCI_ENGINE_RUN_OPTS}" ]
+then
+  export RB_OCI_ENGINE_RUN_OPTS=$DEFAULT_engine_runopts
+fi
+if [ -z "${RB_OCI_VOLUME_FLAGS}" ]
+then
+  export RB_OCI_VOLUME_FLAGS=$DEFAULT_volumeflags;
+fi
+
 echo
 case ${tool} in
   mvn*)


### PR DESCRIPTION
(had to create a new branch, as I rebased my branch by mistake)

These changes allow me to run a (randomly chosen) maven build:

```console
$ ./rebuild.sh content/commons-io/commons-io-2.16.1.buildspec
...
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  24.705 s
[INFO] Finished at: 2024-05-19T18:55:25Z
[INFO] ------------------------------------------------------------------------
dos2unix: converting file target/commons-io-2.16.1.buildinfo to Unix format...
dos2unix: converting file target/commons-io-2.16.1.buildcompare to Unix format...

[INFO] rebuild from content/commons-io/commons-io-2.16.1.buildspec
[INFO]   results in content/commons-io/commons-io-2.16.1.buildinfo
[INFO] compared to Central Repository content/commons-io/commons-io-2.16.1.buildcompare:
    ok=7
    okFiles="commons-io-2.16.1.pom commons-io-2.16.1.jar commons-io-2.16.1-tests.jar commons-io-2.16.1-sources.jar commons-io-2.16.1-test-sources.jar commons-io-2.16.1-cyclonedx.xml commons-io-2.16.1-cyclonedx.json"
    ignored=1
    ignoredFiles=commons-io-2.16.1.spdx.json
```

Let me know if it breaks anything for you/docker.
