### PR TITLE
add opentelemetry-java 1.39.0-SNAPSHOT wip

### DIFF
--- a/wip/opentelemetry-java-1.39.0.buildspec
+++ b/wip/opentelemetry-java-1.39.0.buildspec
@@ -1,0 +1,18 @@
+groupId=io.opentelemetry
+artifactId=opentelemetry-bom
+display=${groupId}:${artifactId}
+# note, file name and version value are out-of-sync
+version=1.39.0-SNAPSHOT
+
+gitRepo=https://github.com/open-telemetry/opentelemetry-java.git
+gitTag=v${version}
+
+tool=gradle
+jdk=17
+newline=lf
+
+command="./gradlew --no-daemon clean assemble publishToMavenLocal -x test"
+buildinfo=${artifactId}-${version}.buildinfo
+
+diffoscope=${artifactId}-${version}.diffoscope
+issue=https://github.com/open-telemetry/opentelemetry-java/issues/4488


### PR DESCRIPTION
Maybe fix #171. Adds a wip buildspec for `io.opentelemetry:opentelemetry-java`.

While open-telemetry/opentelemetry-java#4488 is accepted, I don't think they have yet merged and/or published a SNAPSHOT build yet.  So I'm skeptical this will pass at first.

Note that the project is named `opentelemetry-java`, but our entry point artifact would be `opentelemetry-bom` as with JUnit5.

Also, this wip buildspec does not include the SNAPSHOT label in the filename, but the version key/value pair does.  I assume we can tweak this before merging.