### PR TITLE
Provide badge status for projects

### DIFF
--- a/bin/update-reproducibility-summary.sh
+++ b/bin/update-reproducibility-summary.sh
@@ -188,11 +188,11 @@ do
   done
 
   # Make badge status file
-  badgeMessage="latest OK"
+  badgeMessage="${latestVersion} OK"
   badgeColor="green"
   badgeError="false"
   if [[ "${showOkBadge}" == "0" ]]; then
-      badgeMessage="latest FAIL"
+      badgeMessage="${latestVersion} FAIL"
       badgeColor="red"
       badgeError="true"
   fi


### PR DESCRIPTION
This PR provides a suggested fix for #79

If the bash-fu is not optimal for your style, please adapt as you see fit.

You may want to tweak the message so it includes Reproducible Builds or something.
Entirely up to you.

I must admit I did not spend enough time to determine if it is possible to merge a "standard" badge with the endpoint magic.


The provided `badge-status.json` file can be used similar to this: 

```text
https://img.shields.io/endpoint?url=https%3A%2F%2Fraw.githubusercontent.com%2Fjvm-repo-rebuild%2Freproducible-central%2Fmaster%2Fcontent%2F...path to project directory...%2Fbadge-status.json
```