### PR TITLE
make README links use modules from newest release with .buildinfo

### DIFF
--- a/bin/update-reproducibility-summary.sh
+++ b/bin/update-reproducibility-summary.sh
@@ -86,6 +86,17 @@ do
       break
     fi
   done
+  # detect newest version that has a buildinfo file
+  newestBuildinfoVersion=
+  for version in $($tac "${metadata}" | grep 'version>' | cut -d '>' -f 2 | cut -d '<' -f 1)
+  do
+    if [ -n "$(ls $dir | grep "\-${version}\.buildinfo")" ]
+    then
+      newestBuildinfoVersion="$version"
+      break
+    fi
+  done
+
   latestVersion="$(cat "${metadata}" | grep 'latest>' | cut -d '>' -f 2 | cut -d '<' -f 1)"
   lastUpdated="$(cat "${metadata}" | grep 'lastUpdated>' | cut -d '>' -f 2 | cut -d '<' -f 1)"
 
@@ -132,15 +143,15 @@ do
         echo "Source code: [$gitRepo]($gitRepo)" >> ${projectReadme}
         echo >> ${projectReadme}
 
-        projectGa="$(( $(cat $dir/*.buildinfo | grep coordinates | cut -d = -f 2 | sort -u | wc -l) ))"
+        projectGa="$(( $(cat $dir/*-${newestBuildinfoVersion}\.buildinfo | grep coordinates | cut -d = -f 2 | sort -u | wc -l) ))"
         if [ $projectGa -gt 1 ]
         then
           echo "<details><summary>This project defines $projectGa modules:</summary>" >> ${projectReadme}
           echo >> ${projectReadme}
-          for ga in $(cat $dir/*.buildinfo | grep coordinates | cut -d = -f 2 | sort -u)
+          for ga in $(cat $dir/*-${newestBuildinfoVersion}\.buildinfo | grep coordinates | cut -d = -f 2 | sort -u)
           do
             gaDir=$(echo "$ga" | sed -e 's_:_/_')
-            echo "* [$ga](https://central.sonatype.com/artifact/${gaDir}/${version})" >> ${projectReadme}
+            echo "* [$ga](https://central.sonatype.com/artifact/${gaDir}/${newestBuildinfoVersion})" >> ${projectReadme}
           done
           echo "</details>" >> ${projectReadme}
           echo >> ${projectReadme}


### PR DESCRIPTION
Updates the `bin/update-reproducibility-summary.sh` script so that the README file overview links only include modules determined from the newest _released_ version .buildinfo file.

I have made this PR a draft for now, as it currently incorporates my changes from #194, which is similarly a draft. I did that because I wanted to verify that it still selected 2.36.0 modules for the README links for artemis, since 2.37.0 is still not released. I'll update the PR to address that later, either removing those changes, or once it is released and added.

I also wasnt sure whether this PR should include _just_ the script changes, or _all_ of the updates it causes. I thought it worth raising the draft PR with them all included for now so that the overall effect can be observed for review, even if the non-script updates should then be removed and left for the CI refresh to apply after merge.