### PR TITLE
Jdk22 tool chains

### DIFF
--- a/bin/docker/Dockerfile.environment.template
+++ b/bin/docker/Dockerfile.environment.template
@@ -29,20 +29,20 @@ RUN chmod 755 /scripts/*.sh
 ###
 ADD docker/mvn /usr/local/bin
 RUN chmod 755 /usr/local/bin/mvn
-ENV PATH /usr/local/bin/:${PATH}
+ENV PATH="/usr/local/bin/:${PATH}"
 
 # Avoid out of memory errors in builds
-ENV MAVEN_OPTS -Xms256m -Xmx512m @@MAVEN_OPTS@@
+ENV MAVEN_OPTS="-Xms256m -Xmx512m @@MAVEN_OPTS@@"
 
 ###
 # Better reproducibility: Make the desired locale explicit
 # Set the locale ( see https://stackoverflow.com/a/28406007/114196 )
 ###
-ENV BUILD_LOCALE @@BUILD_LOCALE@@
+ENV BUILD_LOCALE=@@BUILD_LOCALE@@
 RUN [ -f /etc/locale.gen ] && sed -i "/${BUILD_LOCALE}.UTF-8/s/^# //g" /etc/locale.gen && locale-gen || true
-ENV LANG ${BUILD_LOCALE}.UTF-8
-ENV LANGUAGE ${BUILD_LOCALE}
-ENV LC_ALL ${BUILD_LOCALE}.UTF-8
+ENV LANG=${BUILD_LOCALE}.UTF-8
+ENV LANGUAGE=${BUILD_LOCALE}
+ENV LC_ALL=${BUILD_LOCALE}.UTF-8
 
 ###
 # Better reproducibility: Make the desired umask explicit
@@ -55,7 +55,7 @@ ENV BUILD_UMASK=@@BUILD_UMASK@@
 ENV BUILD_TIMEZONE=@@BUILD_TIMEZONE@@
 
 ENV TZ=${BUILD_TIMEZONE}
-ENV MAVEN_OPTS -Duser.timezone=${BUILD_TIMEZONE}
+ENV MAVEN_OPTS="-Duser.timezone=${BUILD_TIMEZONE}"
 
 RUN ln -fs /usr/share/zoneinfo/${BUILD_TIMEZONE} /etc/localtime && \
     dpkg-reconfigure -f noninteractive tzdata && \

--- a/bin/docker/Dockerfile.fix-preinstalled-java.include
+++ b/bin/docker/Dockerfile.fix-preinstalled-java.include
@@ -15,29 +15,12 @@
 ###
 # If we are using an image with a preinstalled Java the configs for the update-java-alternatives are broken
 
-# Because we are copying and then modifying the Java 21 configs we need that to be installed also
-RUN [ -f /usr/lib/jvm/.java-1.21.0-openjdk-amd64.jinfo ] || ( echo "You MUST have JDK 21 installed also when using a non-LTS JDK so we can copy some of the configs" && exit 1 )
+RUN [ -d /scripts ] || mkdir /scripts
+ADD docker/register-pre-installed-java.sh /scripts/
+RUN chmod 755 /scripts/register-pre-installed-java.sh
+RUN /scripts/register-pre-installed-java.sh
 
-# Remove the preinstalled from the PATH
+# Remove the preinstalled from the PATH because the interferes with the alternatives mechanism
 ENV PATH="$(echo $PATH | sed 's@:/opt/java/openjdk/bin:@:@g')"
 ENV JAVA_HOME=
 ENV JAVA_VERSION=
-
-# Steps:
-# 1. Figure out the installed non-LTS major version
-# 2. Copy the Java 21 config to the installed one
-# 3. Tell update-alternatives about all the files we have
-RUN cd /usr/lib/jvm/ && \
-    JAVAMAJORVERSION=$(/opt/java/openjdk/bin/java --version | head -1 | cut -d' ' -f2 | cut -d'.' -f1); \
-    ln -s /opt/java/openjdk/ java-${JAVAMAJORVERSION}-openjdk-amd64 ; \
-    ln -s java-${JAVAMAJORVERSION}-openjdk-amd64 java-1.${JAVAMAJORVERSION}.0-openjdk-amd64 ; \
-    sed "s@21@${JAVAMAJORVERSION}@g" .java-1.21.0-openjdk-amd64.jinfo > .java-1.${JAVAMAJORVERSION}.0-openjdk-amd64.jinfo; \
-    JDKNAME=$(cat /usr/lib/jvm/.java-1.${JAVAMAJORVERSION}.0-openjdk-amd64.jinfo | fgrep name= | cut -d'=' -f2 ); \
-    JDKALIAS=$(cat /usr/lib/jvm/.java-1.${JAVAMAJORVERSION}.0-openjdk-amd64.jinfo | fgrep alias= | cut -d'=' -f2 ); \
-    JDKPRIO=$(cat /usr/lib/jvm/.java-1.${JAVAMAJORVERSION}.0-openjdk-amd64.jinfo | fgrep priority= | cut -d'=' -f2 ); \
-    fgrep /usr/lib/jvm/ /usr/lib/jvm/.java-1.${JAVAMAJORVERSION}.0-openjdk-amd64.jinfo | \
-    while read type name path ; \
-    do \
-        update-alternatives --install /usr/bin/${name} ${name} ${path} ${JDKPRIO}; \
-    done
-

--- a/bin/docker/Dockerfile.fix-preinstalled-java.include
+++ b/bin/docker/Dockerfile.fix-preinstalled-java.include
@@ -1,0 +1,43 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+###
+# If we are using an image with a preinstalled Java the configs for the update-java-alternatives are broken
+
+# Because we are copying and then modifying the Java 21 configs we need that to be installed also
+RUN [ -f /usr/lib/jvm/.java-1.21.0-openjdk-amd64.jinfo ] || ( echo "You MUST have JDK 21 installed also when using a non-LTS JDK so we can copy some of the configs" && exit 1 )
+
+# Remove the preinstalled from the PATH
+ENV PATH="$(echo $PATH | sed 's@:/opt/java/openjdk/bin:@:@g')"
+ENV JAVA_HOME=
+ENV JAVA_VERSION=
+
+# Steps:
+# 1. Figure out the installed non-LTS major version
+# 2. Copy the Java 21 config to the installed one
+# 3. Tell update-alternatives about all the files we have
+RUN cd /usr/lib/jvm/ && \
+    JAVAMAJORVERSION=$(/opt/java/openjdk/bin/java --version | head -1 | cut -d' ' -f2 | cut -d'.' -f1); \
+    ln -s /opt/java/openjdk/ java-${JAVAMAJORVERSION}-openjdk-amd64 ; \
+    ln -s java-${JAVAMAJORVERSION}-openjdk-amd64 java-1.${JAVAMAJORVERSION}.0-openjdk-amd64 ; \
+    sed "s@21@${JAVAMAJORVERSION}@g" .java-1.21.0-openjdk-amd64.jinfo > .java-1.${JAVAMAJORVERSION}.0-openjdk-amd64.jinfo; \
+    JDKNAME=$(cat /usr/lib/jvm/.java-1.${JAVAMAJORVERSION}.0-openjdk-amd64.jinfo | fgrep name= | cut -d'=' -f2 ); \
+    JDKALIAS=$(cat /usr/lib/jvm/.java-1.${JAVAMAJORVERSION}.0-openjdk-amd64.jinfo | fgrep alias= | cut -d'=' -f2 ); \
+    JDKPRIO=$(cat /usr/lib/jvm/.java-1.${JAVAMAJORVERSION}.0-openjdk-amd64.jinfo | fgrep priority= | cut -d'=' -f2 ); \
+    fgrep /usr/lib/jvm/ /usr/lib/jvm/.java-1.${JAVAMAJORVERSION}.0-openjdk-amd64.jinfo | \
+    while read type name path ; \
+    do \
+        update-alternatives --install /usr/bin/${name} ${name} ${path} ${JDKPRIO}; \
+    done
+

--- a/bin/docker/Dockerfile.maven.template
+++ b/bin/docker/Dockerfile.maven.template
@@ -1,0 +1,25 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+FROM @@BASEIMAGE@@
+
+# --------------------------------
+# Install Maven ( https://maven.apache.org/download.cgi )
+ENV MAVEN_VERSION=@@MAVEN_VERSION@@
+ENV MAVEN_MAJOR=@@MAVEN_MAJOR@@
+RUN mkdir -p /usr/local/apache-maven
+RUN cd /usr/local/ && wget "https://archive.apache.org/dist/maven/maven-${MAVEN_MAJOR}/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
+RUN cd /usr/local/ && tar xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz --strip-components 1 -C /usr/local/apache-maven
+ENV M2_HOME=/usr/local/apache-maven
+ENV PATH=${M2_HOME}/bin:${PATH}
+RUN ln -s /usr/local/apache-maven/bin/mvn /usr/bin/mvn

--- a/bin/docker/Dockerfile.toolchains.template
+++ b/bin/docker/Dockerfile.toolchains.template
@@ -70,9 +70,10 @@ RUN apt clean cache \
     graphviz
 
 # By running the JDKs as a separate command they become a separate layer and thus we have less layers if we need to do more builds.
+# Adding 'bash' as a dummy to ensure the command is always valid (even if there are no additional JDKs to install)
 RUN apt-get -q update \
     && apt-get -q install -y --no-install-recommends \
-    @@JDKPACKAGES@@
+    bash @@JDKPACKAGES@@
 
 # Avoid out of memory errors in builds
 ENV MAVEN_OPTS="-Xms256m -Xmx512m"

--- a/bin/docker/Dockerfile.toolchains.template
+++ b/bin/docker/Dockerfile.toolchains.template
@@ -11,9 +11,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-FROM docker.io/library/ubuntu:22.04
+FROM @@BASEIMAGE@@
 
-ENV INSIDE_DOCKER Yes
+ENV INSIDE_DOCKER=Yes
 
 ARG DEBIAN_FRONTEND=noninteractive
 
@@ -27,8 +27,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN echo APT::Install-Recommends "0"\; > /etc/apt/apt.conf.d/10disableextras
 RUN echo APT::Install-Suggests "0"\; >>  /etc/apt/apt.conf.d/10disableextras
 
-ENV DEBIAN_FRONTEND noninteractive
-ENV DEBCONF_TERSE true
+ENV DEBIAN_FRONTEND=noninteractive
+ENV DEBCONF_TERSE=true
 
 ###
 # Because of repeated 404 errors on that site during `apt-get install`
@@ -75,7 +75,7 @@ RUN apt-get -q update \
     @@JDKPACKAGES@@
 
 # Avoid out of memory errors in builds
-ENV MAVEN_OPTS -Xms256m -Xmx512m
+ENV MAVEN_OPTS="-Xms256m -Xmx512m"
 
 ##################################################################################################
 # Better reproducibility: deliberately set a few key default settings to a very uncommon value
@@ -85,7 +85,7 @@ ENV MAVEN_OPTS -Xms256m -Xmx512m
 # Set the locale ( see https://stackoverflow.com/a/28406007/114196 )
 # Better reproducibility: deliberately set default locale VERY different from 'US'
 ###
-ENV BUILD_LOCALE fi_FI
+ENV BUILD_LOCALE=fi_FI
 
 ###
 # Better reproducibility: deliberately set default umask VERY strange
@@ -98,7 +98,7 @@ ENV BUILD_UMASK=0055
 ENV BUILD_TIMEZONE=Australia/Eucla
 
 ENV TZ=${BUILD_TIMEZONE}
-ENV MAVEN_OPTS -Duser.timezone=${BUILD_TIMEZONE}
+ENV MAVEN_OPTS="-Duser.timezone=${BUILD_TIMEZONE}"
 RUN ln -fs /usr/share/zoneinfo/${BUILD_TIMEZONE} /etc/localtime && \
     dpkg-reconfigure -f noninteractive tzdata
 

--- a/bin/docker/Dockerfile.toolchains.template
+++ b/bin/docker/Dockerfile.toolchains.template
@@ -104,25 +104,20 @@ RUN ln -fs /usr/share/zoneinfo/${BUILD_TIMEZONE} /etc/localtime && \
 
 ##################################################################################################
 
-# --------------------------------
-# Install Maven ( https://maven.apache.org/download.cgi )
-ENV MAVEN_VERSION=@@MAVEN_VERSION@@
-ENV MAVEN_MAJOR=@@MAVEN_MAJOR@@
-RUN mkdir -p /usr/local/apache-maven
-RUN cd /usr/local/ && wget "https://archive.apache.org/dist/maven/maven-${MAVEN_MAJOR}/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz"
-RUN cd /usr/local/ && tar xzf apache-maven-${MAVEN_VERSION}-bin.tar.gz --strip-components 1 -C /usr/local/apache-maven
-ENV M2_HOME /usr/local/apache-maven
-ENV PATH ${M2_HOME}/bin:${PATH}
-RUN ln -s /usr/local/apache-maven/bin/mvn /usr/bin/mvn
+###ADDITIONAL-JAVA-FIXES###
 
 ###
 # The update-java-alternatives uses the config files like /usr/lib/jvm/.java-1.8.0-openjdk-amd64.jinfo
+###
 # Some of these files contain a reference to mozilla-javaplugin.so which we do not need AND which does not exist
 # in this docker image. So we remove this reference as it will give a needless warning every time we switch JDK.
-###
 RUN sed -i '/^plugin mozilla-javaplugin.so.*$/d' /usr/lib/jvm/.java-*
+###
+# The jaotc reference (only in java 11) breaks changing java version.
+RUN sed -i '/^jdkhl jaotc .*$/d' /usr/lib/jvm/.java-*
+###
 
 ###
 # Activate the selected JDK as the default
 ###
-RUN update-java-alternatives --set "$(update-java-alternatives -l | fgrep "@@JDK@@" | sed 's@ \+@ @g' | cut -d' ' -f1)"
+RUN update-java-alternatives --set "$(update-java-alternatives -l | cut -d' ' -f1 | fgrep "@@JDK@@" | sort | head -1)"

--- a/bin/docker/env.sh
+++ b/bin/docker/env.sh
@@ -25,7 +25,7 @@ then
 
   function SwitchJDK {
       local JDK=$1
-      update-java-alternatives -l | fgrep "${JDK}" > /dev/null
+      update-java-alternatives -l | fgrep ".${JDK}." > /dev/null
       if [ $? -ne 0 ];
       then
         fail "JDK ${JDK} is not available"
@@ -34,7 +34,7 @@ then
       else
         echo -e "${IRed}${On_Black}Setting JDK to version ${JDK}${Color_Off}"
         sudo update-java-alternatives --set $(update-java-alternatives -l | cut -d' ' -f1 | fgrep "${JDK}." );
-        export JAVA_HOME=$(update-java-alternatives -l | fgrep "${JDK}" | sed 's@ \+@ @g' | cut -d' ' -f3);
+        export JAVA_HOME=$(update-java-alternatives -l | fgrep ".${JDK}." | sed 's@ \+@ @g' | cut -d' ' -f3);
         export JDK_VERSION="JDK $(javac -version 2>&1 | cut -d' ' -f2)"
       fi
   }

--- a/bin/docker/generate-toolchains.sh
+++ b/bin/docker/generate-toolchains.sh
@@ -1,4 +1,17 @@
 #!/bin/bash
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
 # Output of update-java-alternatives -l
 #java-1.11.0-openjdk-amd64      1111       /usr/lib/jvm/java-1.11.0-openjdk-amd64

--- a/bin/docker/mvn
+++ b/bin/docker/mvn
@@ -6,6 +6,8 @@
 info "Generating /var/maven/.m2/toolchains.xml"
 . "/scripts/generate-toolchains.sh" > /var/maven/.m2/toolchains.xml
 
+warn "Using JDK version $(javac --version | cut -d' ' -f2)"
+
 # Better reproducibility: deliberately set the umask to something total insane
 umask ${BUILD_UMASK}
 warn "The UMASK    has been set to: $(umask)"

--- a/bin/docker/register-pre-installed-java.sh
+++ b/bin/docker/register-pre-installed-java.sh
@@ -1,0 +1,91 @@
+#!/bin/bash -x
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# Where is Java
+JAVA_APP=$(which java)
+JAVA_HOME_BIN=$( echo $JAVA_APP | sed 's@/java$@@' )
+JAVA_HOME=$( echo $JAVA_APP | sed 's@/bin/java$@@' )
+JAVA_MAJOR_VERSION=$( "${JAVA_APP}" --version | head -1 | cut -d' ' -f2 | cut -d'.' -f1)
+
+MACHINE_TYPE=$(uname -m)
+
+case "$MACHINE_TYPE" in
+  x86_64)
+    MACHINE_TYPE=amd64
+    ;;
+esac
+
+JAVA_NAME=java-${JAVA_MAJOR_VERSION}-openjdk-${MACHINE_TYPE}
+JAVA_ALIAS=java-1.${JAVA_MAJOR_VERSION}.0-openjdk-${MACHINE_TYPE}
+JAVA_PRIO=${JAVA_MAJOR_VERSION}00
+[ -d /usr/lib/jvm/ ] || mkdir -p /usr/lib/jvm/
+cd /usr/lib/jvm/ || exit 1
+ln -s "${JAVA_HOME}" "${JAVA_NAME}"
+ln -s "${JAVA_NAME}" "${JAVA_ALIAS}"
+
+JINFO_FILE="/usr/lib/jvm/.${JAVA_ALIAS}.jinfo"
+
+(
+echo "name=${JAVA_NAME}"
+echo "alias=${JAVA_ALIAS}"
+echo "priority=${JAVA_PRIO}"
+echo "section=main"
+echo ""
+) > "${JINFO_FILE}"
+
+TOOL_BIN_DIR="/usr/lib/jvm/${JAVA_ALIAS}/bin/"
+
+for tool in "hl java" \
+            "hl jpackage" \
+            "hl keytool" \
+            "hl rmiregistry" \
+            "hl jexec" \
+            "jdkhl jar" \
+            "jdkhl jarsigner" \
+            "jdkhl javac" \
+            "jdkhl javadoc" \
+            "jdkhl javap" \
+            "jdkhl jcmd" \
+            "jdkhl jdb" \
+            "jdkhl jdeprscan" \
+            "jdkhl jdeps" \
+            "jdkhl jfr" \
+            "jdkhl jimage" \
+            "jdkhl jinfo" \
+            "jdkhl jlink" \
+            "jdkhl jmap" \
+            "jdkhl jmod" \
+            "jdkhl jps" \
+            "jdkhl jrunscript" \
+            "jdkhl jshell" \
+            "jdkhl jstack" \
+            "jdkhl jstat" \
+            "jdkhl jstatd" \
+            "jdkhl jwebserver" \
+            "jdkhl serialver" \
+            "jdkhl jhsdb" \
+            "jdk jconsole"
+do
+  tool_array=( $tool )
+  TOOL_TYPE="${tool_array[0]}"
+  TOOL_NAME="${tool_array[1]}"
+
+  if [ -f "${TOOL_BIN_DIR}/${TOOL_NAME}" ];
+  then
+    echo "${TOOL_TYPE} ${TOOL_NAME} ${TOOL_BIN_DIR}${TOOL_NAME}" >> "${JINFO_FILE}"
+    update-alternatives --install /usr/bin/${TOOL_NAME} ${TOOL_NAME} ${TOOL_BIN_DIR}${TOOL_NAME} ${JAVA_PRIO}
+  fi
+done
+

--- a/wip/yauaa-7.28.1.buildspec
+++ b/wip/yauaa-7.28.1.buildspec
@@ -1,0 +1,31 @@
+# Central Repository coordinates for the Reference release (for multi-module, pick an arbitrary module)
+groupId=nl.basjes.parse.useragent
+artifactId=yauaa
+version=7.28.1
+
+display=${groupId}:${artifactId}
+
+# Source code
+gitRepo=https://github.com/nielsbasjes/yauaa.git
+gitTag=v${version}
+
+# Rebuild environment prerequisites
+tool=mvn-3.9.9
+
+# All LTS JDK versions and JDK-21 is the default (used to start Maven with)
+jdk=21
+toolchains="8|11|17|21|22"
+umask=0002
+timezone=UTC
+newline=lf
+# crlf for Windows, lf for Unix
+
+# Rebuild command
+command='mvn clean verify -PskipQuality -PJava22'
+
+# Location of the buildinfo file generated during rebuild to record output fingerprints
+buildinfo=target/yauaa-parent-${version}.buildinfo
+
+# if the release is finally not reproducible, link to an issue tracker entry if one was created or diffoscope result
+#diffoscope=yauaa-parent-${version}.diffoscope
+issue=


### PR DESCRIPTION
Open problems:

An image with this
```
tool=mvn-3.9.9
jdk=21
toolchains="8|17|21|22"
```
should have jdk 22 in the toolchains and jdk 21 as the default.
Both are not the case yet.


```
# update-java-alternatives -l 
java-1.11.0-openjdk-amd64      1111       /usr/lib/jvm/java-1.11.0-openjdk-amd64
java-1.17.0-openjdk-amd64      1711       /usr/lib/jvm/java-1.17.0-openjdk-amd64
java-1.21.0-openjdk-amd64      2111       /usr/lib/jvm/java-1.21.0-openjdk-amd64
java-1.8.0-openjdk-amd64       1081       /usr/lib/jvm/java-1.8.0-openjdk-amd64
```

```
# update-java-alternatives --set "$(update-java-alternatives -l | fgrep "21" | sed 's@ \+@ @g' | cut -d' ' -f1)" 
update-alternatives: error: no alternatives for jaotc
```