### PR TITLE
fix: improve crlf support for gradle

### DIFF
--- a/bin/includes/rebuildToolGradle.sh
+++ b/bin/includes/rebuildToolGradle.sh
@@ -55,6 +55,11 @@ rebuildToolGradle() {
   if [ $? -eq 0 ]; then
       # output content is expected to be available in repository/ directory
 
+      # fix line endings of pom files for gradle on windows
+      if [[ "${newline}" == crlf* ]]; then
+        find ${OUTPUTDIR} -name "*.pom" -exec sed -i -z "s/\n/\r\n/g" {} \;
+      fi
+
       # compare against reference from Maven Central and generate buildinfo and buildcompare
       compareOutput ${OUTPUTDIR}
   fi


### PR DESCRIPTION
Gradle produces pom files with line endings congruent to the system line separator property. See https://github.com/gradle/gradle/issues/19866 and https://discuss.gradle.org/t/poms-are-written-with-the-default-line-ending-of-the-platform/1667 for example

If a project was initially built on windows, when we build with linux, none of the pom files are reproduced due to clashing line endings

This PR converts LF to CRLF for the generated pom files when running gradle in crlf* mode
