### PR TITLE
Only run scheduled workflows on jvm-repo-rebuild/reproducible-central

### DIFF
--- a/.github/workflows/update-rb-ubuntu.yml
+++ b/.github/workflows/update-rb-ubuntu.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'jvm-repo-rebuild/reproducible-central'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/update-reports.yml
+++ b/.github/workflows/update-reports.yml
@@ -9,6 +9,7 @@ on:
 
 jobs:
   build:
+    if: github.repository == 'jvm-repo-rebuild/reproducible-central'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
I have tested that it successfully disables workflow runs in my clone.

But you should double check that it still works on your repo :)