### PR TITLE
fix: use https to clone `atom-jaxb`

### DIFF
--- a/content/fr/vidal/oss/atom-jaxb-1.1.0.buildspec
+++ b/content/fr/vidal/oss/atom-jaxb-1.1.0.buildspec
@@ -8,7 +8,7 @@ version=1.1.0
 display=${groupId}:${artifactId}
 
 # Source code
-gitRepo=git@github.com:vidal-community/atom-jaxb.git
+gitRepo=https://github.com/vidal-community/atom-jaxb
 gitTag=v${version}
 
 # Rebuild environment prerequisites


### PR DESCRIPTION
I was running `./rebuild.sh` on a server and I don't have my ssh credentials configured so the clone failed. Proposing this to ensure no breakage.