### PR TITLE
Update cache-api-0.7.1.buildspec

### DIFF
--- a/content/io/github/xanthic/cache/cache-api/cache-api-0.7.1.buildspec
+++ b/content/io/github/xanthic/cache/cache-api/cache-api-0.7.1.buildspec
@@ -12,7 +12,7 @@ jdk=21
 newline=lf
 umask=022
 
-command="./gradlew --no-daemon -Pgnupg.skip clean assemble publishToMavenLocal -x test -x :cache-kotlin:kotlinSourcesJar"
+command="./gradlew --no-daemon -Pgnupg.skip clean assemble publishToMavenLocal -x test"
 buildinfo=${artifactId}-${version}.buildinfo
 
 #diffoscope=${artifactId}-${version}.diffoscope


### PR DESCRIPTION
workaround from #1363 is no longer needed
