### PR TITLE
Don't remove `build` directories in the Gradle rebuild

### DIFF
--- a/bin/includes/rebuildToolGradle.sh
+++ b/bin/includes/rebuildToolGradle.sh
@@ -35,7 +35,6 @@ rebuildToolGradle() {
   [ -d userhome/.m2 ] || mkdir -p userhome/.m2
   [ -d userhome/.gradle ] || mkdir -p userhome/.gradle
   [ -d $PWD/.bnd ] || mkdir -p $PWD/.bnd
-  find . -name build -exec \rm -rf {} \;
 
   [ "${workdir}" = "" ] && workdir="/var/gradle/app"
 


### PR DESCRIPTION
Hey 👋🏻 😃,

I was looking into adding one more Hibernate project to the list, but encountered a problem with this Gradle rebuild script (among some other things). 
We have some packages called `build` (e.g. https://github.com/hibernate/hibernate-orm/tree/main/local-build-plugins/src/main/java/org/hibernate/build) and running that `rm` leads to build failures as parts of the code are missing. 

Or was there some specific reason for this `rm` that I'm missing?