### PR TITLE
fix: log correct path for reference and rebuild artifacts

### DIFF
--- a/bin/includes/displayResult.sh
+++ b/bin/includes/displayResult.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
 
 displayResult() {
-  local buildcompare version ok ko okFiles koFiles reference_java_version reference_os_name
+  local pomDirectory="$1"
+  local buildcompare version ok ko okFiles koFiles reference_java_version reference_os_name pomDirectoryInBuildcache
   buildcompare="$(dirname "${buildinfo}")/$(basename ${buildinfo} .buildinfo).buildcompare"
 
   info "rebuild from \033[1m${buildspec}\033[0m"
@@ -28,13 +29,19 @@ displayResult() {
     then
       info "    check .buildspec \033[1mnewline=${newline}\033[0m vs reference \033[1mos.name=${reference_os_name}\033[0m (newline should be crlf if os.name is Windows, lf instead)"
     fi
-    info "build available in \033[1m$(dirname ${buildspec})/buildcache/${artifactId}\033[0m, where you can execute \033[36mdiffoscope\033[0m"
+    if [[ -z $pomDirectory ]]
+    then
+      pomDirectoryInBuildcache="buildcache/${artifactId}"
+    else
+      pomDirectoryInBuildcache="buildcache/${artifactId}/${pomDirectory}"
+    fi
+    info "build available in \033[1m$(dirname ${buildspec})/${pomDirectoryInBuildcache}\033[0m, where you can execute \033[36mdiffoscope\033[0m"
     grep '# diffoscope ' ${buildcompare}
 #    echo -e "run \033[36mdiffoscope\033[0m as container with \033[1mdocker run --rm -t -w /mnt -v $(pwd):/mnt:ro registry.salsa.debian.org/reproducible-builds/diffoscope\033[0m"
     info "To see every differences between current rebuild and reference, run:"
     if [ -z "${sourcePath}" ]
     then
-      info "    \033[1m./build_diffoscope.sh $(dirname ${buildspec})/$(basename ${compare}) buildcache/${artifactId}\033[0m"
+      info "    \033[1m./build_diffoscope.sh $(dirname ${buildspec})/$(basename ${compare}) $pomDirectoryInBuildcache\033[0m"
     else
       info "    \033[1m./build_diffoscope.sh $(dirname ${buildspec})/$(basename ${compare}) buildcache/${sourcePath}\033[0m"
     fi

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -116,9 +116,9 @@ esac
 
 echo
 
-pomFile=$(echo "$command" | grep -oP '(?<=-f )[^ ]+')
+pomFile=$(echo "$command" | sed -nE 's/.*-f ([^ ]+).*/\1/p')
 if [ -n "$pomFile" ]; then
-  displayResult $(dirname $pomFile)
+  displayResult "$(dirname "$pomFile")"
 else
   displayResult ""
 fi

--- a/rebuild.sh
+++ b/rebuild.sh
@@ -115,7 +115,13 @@ case ${tool} in
 esac
 
 echo
-displayResult
+
+pomFile=$(echo "$command" | grep -oP '(?<=-f )[^ ]+')
+if [ -n "$pomFile" ]; then
+  displayResult $(dirname $pomFile)
+else
+  displayResult ""
+fi
 
 displayOptional  "os"
 displayOptional  "arch"


### PR DESCRIPTION
Fixes #1779 

I chose to go with fixing at `./rebuild.sh` level rather than `maven-artifact-plugin` as I wanted to edit only these two information:
```
[INFO] build available in content/org/apache/orc/buildcache/orc/java, where you can execute diffoscope
[INFO] To see every differences between current rebuild and reference, run:
[INFO]     ./build_diffoscope.sh content/org/apache/orc/orc-1.8.3.buildcompare buildcache/orc/java
```