### PR TITLE
Fix maven version for shiro-2.0.3.buildspec

### DIFF
--- a/content/org/apache/shiro/shiro-2.0.3.buildspec
+++ b/content/org/apache/shiro/shiro-2.0.3.buildspec
@@ -6,12 +6,12 @@ version=2.0.3
 gitRepo=https://github.com/apache/shiro.git
 gitTag=${artifactId}-${version}
 
-tool=mvn-4.0.0-rc-3
+tool=mvn-4.0.0-rc-2
 jdk=23
 newline=lf
 umask=022
 
-command="mvn -Papache-release,skip_jakarta_ee_tests clean package -DskipTests -Dmaven.javadoc.skip -Dgpg.skip -Dmaven.test.skip"
+command="mvn -Papache-release,skip_jakarta_ee_tests clean package -DskipTests -Dmaven.javadoc.skip -Dgpg.skip -Dmaven.test.skip -Dmaven.consumer.pom=true"
 
 buildinfo=target/${artifactId}-${version}.buildinfo
 


### PR DESCRIPTION
Hi,

Shiro 2.0.3 is failing reproducible builds due to wrong maven version and parameters.
This PR uses the correct maven version and parameters for the rebuild.
Thank you!
