### PR TITLE
Remove oras spdx version workarround

### DIFF
--- a/content/land/oras/oras-java-sdk/oras-java-sdk-0.2.6.buildspec
+++ b/content/land/oras/oras-java-sdk/oras-java-sdk-0.2.6.buildspec
@@ -11,6 +11,6 @@ tool=mvn-3.9.9
 jdk=17
 newline=lf
 
-command="mvn -Prelease,quick-build -DskipTests clean verify -Dgpg.skip -Dsigstore.skip -Dspdx-maven-plugin.version=0.7.4"
+command="mvn -Prelease clean verify -Dgpg.skip -Dsigstore.skip -Dspdx.skip=true"
 
 buildinfo=target/${artifactId}-${version}.buildinfo


### PR DESCRIPTION
Version issue was due to https://github.com/spdx/spdx-java-v3jsonld-store/issues/18#event-17323721720
Still remains the SPDX JSON is not reproducible, so ignored for now

Tested with 

```
./rebuild.sh content/land/oras/oras-java-sdk/oras-java-sdk-0.2.6.buildspec
```
