### PR TITLE
Bump JDK requirement for hibernate-models rebuilds since it is usually built with JDK21+ 

### DIFF
--- a/content/org/hibernate/models/hibernate-models/hibernate-models-1.0.0.CR1.buildspec
+++ b/content/org/hibernate/models/hibernate-models/hibernate-models-1.0.0.CR1.buildspec
@@ -13,7 +13,7 @@ gitTag=${version}
 
 # Rebuild environment prerequisites
 tool=gradle
-jdk=17
+jdk=21
 newline=lf
 umask=022
 

--- a/content/org/hibernate/models/hibernate-models/hibernate-models-1.0.0.CR2.buildspec
+++ b/content/org/hibernate/models/hibernate-models/hibernate-models-1.0.0.CR2.buildspec
@@ -13,7 +13,7 @@ gitTag=${version}
 
 # Rebuild environment prerequisites
 tool=gradle
-jdk=17
+jdk=21
 newline=lf
 umask=022
 

--- a/content/org/hibernate/models/hibernate-models/hibernate-models-1.0.0.CR3.buildspec
+++ b/content/org/hibernate/models/hibernate-models/hibernate-models-1.0.0.CR3.buildspec
@@ -13,7 +13,7 @@ gitTag=${version}
 
 # Rebuild environment prerequisites
 tool=gradle
-jdk=17
+jdk=21
 newline=lf
 umask=022
 

--- a/content/org/hibernate/models/hibernate-models/hibernate-models-1.0.0.buildspec
+++ b/content/org/hibernate/models/hibernate-models/hibernate-models-1.0.0.buildspec
@@ -13,7 +13,7 @@ gitTag=${version}
 
 # Rebuild environment prerequisites
 tool=gradle
-jdk=17
+jdk=21
 newline=lf
 umask=022
 


### PR DESCRIPTION
Hey 🙂 👋🏻 

I was looking into why hibernate-models were showing unreproducible builds for recent versions (since we have a CI check to test it and it shows that all seems to be ok) and I noticed this JDK difference.... Ususally `hibernate-models` is built with JDK21. After updating the buildspec and running the rebuild command I get:
```java
[INFO] computing hibernate-models-1.0.0.CR3.buildinfo from content in repository/ directory, downloading equivalent from Maven Central to central/, and comparing: results to hibernate-models-1.0.0.CR3.buildcompare
downloading reference to central/org/hibernate/models/hibernate-models/1.0.0.CR3/hibernate-models-1.0.0.CR3.pom                                                          
[INFO] rebuild from content/org/hibernate/models/hibernate-models/hibernate-models-1.0.0.CR3.buildspec
[INFO]   results in content/org/hibernate/models/hibernate-models/hibernate-models-1.0.0.CR3.buildinfo
[INFO] compared to Central Repository content/org/hibernate/models/hibernate-models/hibernate-models-1.0.0.CR3.buildcompare:
    ok=9
    okFiles="hibernate-models-bytebuddy-1.0.0.CR3-sources.jar hibernate-models-bytebuddy-1.0.0.CR3.jar hibernate-models-bytebuddy-1.0.0.CR3.pom hibernate-models-jandex-1.0.0.CR3-sources.jar hibernate-models-jandex-1.0.0.CR3.jar hibernate-models-jandex-1.0.0.CR3.pom hibernate-models-1.0.0.CR3-sources.jar hibernate-models-1.0.0.CR3.jar hibernate-models-1.0.0.CR3.pom"

------------------------------------------

[INFO] computing hibernate-models-1.0.0.buildinfo from content in repository/ directory, downloading equivalent from Maven Central to central/, and comparing: results to hibernate-models-1.0.0.buildcompare
downloading reference to central/org/hibernate/models/hibernate-models/1.0.0/hibernate-models-1.0.0.pom                                                          
[INFO] rebuild from content/org/hibernate/models/hibernate-models/hibernate-models-1.0.0.buildspec
[INFO]   results in content/org/hibernate/models/hibernate-models/hibernate-models-1.0.0.buildinfo
[INFO] compared to Central Repository content/org/hibernate/models/hibernate-models/hibernate-models-1.0.0.buildcompare:
    ok=9
    okFiles="hibernate-models-bytebuddy-1.0.0-sources.jar hibernate-models-bytebuddy-1.0.0.jar hibernate-models-bytebuddy-1.0.0.pom hibernate-models-jandex-1.0.0-sources.jar hibernate-models-jandex-1.0.0.jar hibernate-models-jandex-1.0.0.pom hibernate-models-1.0.0-sources.jar hibernate-models-1.0.0.jar hibernate-models-1.0.0.pom"

```

Is it enough to update the build specs, or should anything else be done here ? Thanks!