### PR TITLE
style: add meaning of icons used for stabilize

### DIFF
--- a/bin/update-project-summary.sh
+++ b/bin/update-project-summary.sh
@@ -174,7 +174,7 @@ echo >> ${projectReadme}
 echo "stabilizing **$((countVersion - countVersionOk))** releases:" >> ${projectReadme}
 echo "- **${countStabilizeOk}** artifacts were successfully **stabilized** (all unreproducible differences removed :recycle:)" >> ${projectReadme}
 echo "- **${countStabilizeKo}** artifacts were **not stabilized** (some unreproducible differences remain :rotating_light:)" >> ${projectReadme}
-echo "- **${countStabilizeIgnored}** artifacts were ignored as \`stabilize\` threw an exception parsing them (:no_entry_sign:)" >> ${projectReadme}
+echo "- **${countStabilizeIgnored}** artifacts were ignored as \`stabilize\` threw an exception parsing them ( :no_entry_sign: )" >> ${projectReadme}
 echo >> ${projectReadme}
 echo "- **${countStabilizeAnalysisHasntRun}** releases have not been analyzed yet (-)" >> ${projectReadme}
 echo >> ${projectReadme}


### PR DESCRIPTION
It is nice to explain what each icon means in the context of `stabilize`. Examples:

---
rebuilding **17 releases** of org.apache.sling:org.apache.sling.resourceresolver:
- **16** releases were found successfully **fully reproducible** (100% reproducible artifacts :white_check_mark:),
- 1 had issues (some unreproducible artifacts :warning:, see eventual :mag: diffoscope and/or :memo: issue tracker links):

stabilizing **1** releases:
- **3** artifacts were successfully **stabilized** (all unreproducible differences removed :recycle:)
- **0** artifacts were **not stabilized** (some unreproducible differences remain :rotating_light:)
- **0** artifacts were ignored as `stabilize` threw an exception parsing them ( :no_entry_sign: )

- **0** releases have not been analyzed yet (-)

| version | [build spec](/BUILDSPEC.md) | [result](https://reproducible-builds.org/docs/jvm/): reproducible? | [stabilize](https://github.com/google/oss-rebuild/blob/main/cmd/stabilize/README.md) | size |
| -- | --------- | ------ | ------ | -- |
| [2.0.0](https://central.sonatype.com/artifact/org.apache.sling/org.apache.sling.resourceresolver/2.0.0/pom) | [mvn jdk17](org.apache.sling.resourceresolver-2.0.0.buildspec) | [result](org.apache.sling.resourceresolver-2.0.0.buildinfo): [4 :white_check_mark: ](org.apache.sling.resourceresolver-2.0.0.buildcompare) | | 822K |
| [1.12.10](https://central.sonatype.com/artifact/org.apache.sling/org.apache.sling.resourceresolver/1.12.10/pom) | [mvn jdk17](org.apache.sling.resourceresolver-1.12.10.buildspec) | [result](org.apache.sling.resourceresolver-1.12.10.buildinfo): [1 :white_check_mark:  3 :warning:](org.apache.sling.resourceresolver-1.12.10.buildcompare) | 3 :recycle: | 819K |
| [1.12.8](https://central.sonatype.com/artifact/org.apache.sling/org.apache.sling.resourceresolver/1.12.8/pom) | [mvn jdk17](org.apache.sling.resourceresolver-1.12.8.buildspec) | [result](org.apache.sling.resourceresolver-1.12.8.buildinfo): [4 :white_check_mark: ](org.apache.sling.resourceresolver-1.12.8.buildcompare) | | 817K |
| [1.12.6](https://central.sonatype.com/artifact/org.apache.sling/org.apache.sling.resourceresolver/1.12.6/pom) | [mvn jdk11 w](org.apache.sling.resourceresolver-1.12.6.buildspec) | [result](org.apache.sling.resourceresolver-1.12.6.buildinfo): [4 :white_check_mark: ](org.apache.sling.resourceresolver-1.12.6.buildcompare) | | 805K |
...
---
rebuilding **42 releases** of io.opentelemetry.instrumentation:opentelemetry-instrumentation-api:
- **18** releases were found successfully **fully reproducible** (100% reproducible artifacts :white_check_mark:),
- 24 had issues (some unreproducible artifacts :warning:, see eventual :mag: diffoscope and/or :memo: issue tracker links):

stabilizing **24** releases:
- **0** artifacts were successfully **stabilized** (all unreproducible differences removed :recycle:)
- **0** artifacts were **not stabilized** (some unreproducible differences remain :rotating_light:)
- **0** artifacts were ignored as `stabilize` threw an exception parsing them ( :no_entry_sign: )

- **24** releases have not been analyzed yet (-)

| version | [build spec](/BUILDSPEC.md) | [result](https://reproducible-builds.org/docs/jvm/): reproducible? | [stabilize](https://github.com/google/oss-rebuild/blob/main/cmd/stabilize/README.md) | size |
| -- | --------- | ------ | ------ | -- |
| [2.17.0](https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-instrumentation-api/2.17.0/pom) | | | |
| [2.16.0](https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-instrumentation-api/2.16.0/pom) | [gradle jdk21](opentelemetry-2.16.0.buildspec) | [result](opentelemetry-instrumentation-api-2.16.0.buildinfo): [1117 :white_check_mark:  1 :warning:](opentelemetry-instrumentation-api-2.16.0.buildcompare) | - | 82M |
| [2.15.0](https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-instrumentation-api/2.15.0/pom) | [gradle jdk17](opentelemetry-2.15.0.buildspec) | [result](opentelemetry-instrumentation-api-2.15.0.buildinfo): [1106 :white_check_mark:  3 :warning:](opentelemetry-instrumentation-api-2.15.0.buildcompare) | - | 82M |
| [2.14.0](https://central.sonatype.com/artifact/io.opentelemetry.instrumentation/opentelemetry-instrumentation-api/2.14.0/pom) | [gradle jdk17](opentelemetry-2.14.0.buildspec) | [result](opentelemetry-instrumentation-api-2.14.0.buildinfo): [1106 :white_check_mark:  3 :warning:](opentelemetry-instrumentation-api-2.14.0.buildcompare) | - | 81M |
...
---
