### PR TITLE
Update Hibernate Search build spec

### DIFF
--- a/content/org/hibernate/search/hibernate-search-bom/README.md
+++ b/content/org/hibernate/search/hibernate-search-bom/README.md
@@ -7,7 +7,7 @@
 
 Source code: [https://github.com/hibernate/hibernate-search.git](https://github.com/hibernate/hibernate-search.git)
 
-<details><summary>This project defines 22 modules:</summary>
+<details><summary>This project defines 21 modules:</summary>
 
 * [org.hibernate.search:hibernate-search-backend-elasticsearch](https://central.sonatype.com/artifact/org.hibernate.search/hibernate-search-backend-elasticsearch/overview)
 * [org.hibernate.search:hibernate-search-backend-elasticsearch-aws](https://central.sonatype.com/artifact/org.hibernate.search/hibernate-search-backend-elasticsearch-aws/overview)
@@ -25,7 +25,6 @@ Source code: [https://github.com/hibernate/hibernate-search.git](https://github.
 * [org.hibernate.search:hibernate-search-mapper-pojo-base](https://central.sonatype.com/artifact/org.hibernate.search/hibernate-search-mapper-pojo-base/overview)
 * [org.hibernate.search:hibernate-search-mapper-pojo-standalone](https://central.sonatype.com/artifact/org.hibernate.search/hibernate-search-mapper-pojo-standalone/overview)
 * [org.hibernate.search:hibernate-search-platform-bom](https://central.sonatype.com/artifact/org.hibernate.search/hibernate-search-platform-bom/overview)
-* [org.hibernate.search:hibernate-search-platform-common-bom](https://central.sonatype.com/artifact/org.hibernate.search/hibernate-search-platform-common-bom/overview)
 * [org.hibernate.search:hibernate-search-platform-next-bom](https://central.sonatype.com/artifact/org.hibernate.search/hibernate-search-platform-next-bom/overview)
 * [org.hibernate.search:hibernate-search-processor](https://central.sonatype.com/artifact/org.hibernate.search/hibernate-search-processor/overview)
 * [org.hibernate.search:hibernate-search-util-common](https://central.sonatype.com/artifact/org.hibernate.search/hibernate-search-util-common/overview)
@@ -34,13 +33,12 @@ Source code: [https://github.com/hibernate/hibernate-search.git](https://github.
 </details>
 
 rebuilding **15 releases** of org.hibernate.search:hibernate-search-bom:
-- **12** releases were found successfully **fully reproducible** (100% reproducible artifacts :white_check_mark:),
-- 3 had issues (some unreproducible artifacts :warning:, see eventual :mag: diffoscope and/or :memo: issue tracker links):
-  - running [stabilize](doc/stabilize.md) on 1, 0 had all their differences removed :recycle:, 1 still had differences :rotating_light: or files not supported by stabilize :no_entry_sign:
+- **13** releases were found successfully **fully reproducible** (100% reproducible artifacts :white_check_mark:),
+- 2 had issues (some unreproducible artifacts :warning:, see eventual :mag: diffoscope and/or :memo: issue tracker links):
 
 | version | [build spec](/BUILDSPEC.md) | [result](https://reproducible-builds.org/docs/jvm/): reproducible? | [stabilize](https://github.com/google/oss-rebuild/blob/main/cmd/stabilize/README.md) | size |
 | -- | --------- | ------ | ------ | -- |
-| [8.1.0.Alpha1](https://central.sonatype.com/artifact/org.hibernate.search/hibernate-search-bom/8.1.0.Alpha1/pom) | [mvn jdk21](hibernate-search-parent-8.1.0.Alpha1.buildspec) | [result](hibernate-search-parent-8.1.0.Alpha1.buildinfo): [36 :white_check_mark:  1 :warning:](hibernate-search-parent-8.1.0.Alpha1.buildcompare) | 1 :no_entry_sign: | 7.5M |
+| [8.1.0.Alpha1](https://central.sonatype.com/artifact/org.hibernate.search/hibernate-search-bom/8.1.0.Alpha1/pom) | [mvn jdk21](hibernate-search-parent-8.1.0.Alpha1.buildspec) | [result](hibernate-search-parent-8.1.0.Alpha1.buildinfo): [36 :white_check_mark: ](hibernate-search-parent-8.1.0.Alpha1.buildcompare) | | 7.4M |
 | [8.0.0.Final](https://central.sonatype.com/artifact/org.hibernate.search/hibernate-search-bom/8.0.0.Final/pom) | [mvn jdk21](hibernate-search-parent-8.0.0.Final.buildspec) | [result](hibernate-search-parent-8.0.0.Final.buildinfo): [34 :white_check_mark: ](hibernate-search-parent-8.0.0.Final.buildcompare) | | 7.1M |
 | [8.0.0.CR1](https://central.sonatype.com/artifact/org.hibernate.search/hibernate-search-bom/8.0.0.CR1/pom) | [mvn jdk21](hibernate-search-parent-8.0.0.CR1.buildspec) | [result](hibernate-search-parent-8.0.0.CR1.buildinfo): [34 :white_check_mark: ](hibernate-search-parent-8.0.0.CR1.buildcompare) | | 7.1M |
 | [8.0.0.Beta1](https://central.sonatype.com/artifact/org.hibernate.search/hibernate-search-bom/8.0.0.Beta1/pom) | [mvn jdk21](hibernate-search-parent-8.0.0.Beta1.buildspec) | [result](hibernate-search-parent-8.0.0.Beta1.buildinfo): [34 :white_check_mark: ](hibernate-search-parent-8.0.0.Beta1.buildcompare) | | 7.0M |

--- a/content/org/hibernate/search/hibernate-search-bom/badge.json
+++ b/content/org/hibernate/search/hibernate-search-bom/badge.json
@@ -1,6 +1,6 @@
 { "schemaVersion": 1,
   "label": "Reproducible Builds",
   "labelColor": "1e5b96",
-  "message": "36/37",
-  "color": "yellow",
+  "message": "36/36",
+  "color": "green",
   "isError": "true" }

--- a/content/org/hibernate/search/hibernate-search-bom/hibernate-search-parent-8.1.0.Alpha1.buildcompare
+++ b/content/org/hibernate/search/hibernate-search-bom/hibernate-search-parent-8.1.0.Alpha1.buildcompare
@@ -1,16 +1,9 @@
 version=8.1.0.Alpha1
 ok=36
-ko=1
+ko=0
 ignored=0
 okFiles="hibernate-search-bom-8.1.0.Alpha1.pom hibernate-search-platform-bom-8.1.0.Alpha1.pom hibernate-search-platform-next-bom-8.1.0.Alpha1.pom hibernate-search-util-common-8.1.0.Alpha1.pom hibernate-search-util-common-8.1.0.Alpha1.jar hibernate-search-engine-8.1.0.Alpha1.pom hibernate-search-engine-8.1.0.Alpha1.jar hibernate-search-backend-lucene-8.1.0.Alpha1.pom hibernate-search-backend-lucene-8.1.0.Alpha1.jar hibernate-search-backend-elasticsearch-8.1.0.Alpha1.pom hibernate-search-backend-elasticsearch-8.1.0.Alpha1.jar hibernate-search-backend-elasticsearch-aws-8.1.0.Alpha1.pom hibernate-search-backend-elasticsearch-aws-8.1.0.Alpha1.jar hibernate-search-mapper-pojo-base-8.1.0.Alpha1.pom hibernate-search-mapper-pojo-base-8.1.0.Alpha1.jar hibernate-search-mapper-pojo-standalone-8.1.0.Alpha1.pom hibernate-search-mapper-pojo-standalone-8.1.0.Alpha1.jar hibernate-search-mapper-orm-8.1.0.Alpha1.pom hibernate-search-mapper-orm-8.1.0.Alpha1.jar hibernate-search-mapper-orm-outbox-polling-8.1.0.Alpha1.pom hibernate-search-mapper-orm-outbox-polling-8.1.0.Alpha1.jar hibernate-search-mapper-orm-coordination-outbox-polling-8.1.0.Alpha1.pom hibernate-search-mapper-orm-batch-jsr352-core-8.1.0.Alpha1.pom hibernate-search-mapper-orm-batch-jsr352-jberet-8.1.0.Alpha1.pom hibernate-search-mapper-orm-jakarta-batch-core-8.1.0.Alpha1.pom hibernate-search-mapper-orm-jakarta-batch-core-8.1.0.Alpha1.jar hibernate-search-mapper-orm-jakarta-batch-jberet-8.1.0.Alpha1.pom hibernate-search-mapper-orm-jakarta-batch-jberet-8.1.0.Alpha1.jar hibernate-search-v5migrationhelper-engine-8.1.0.Alpha1.pom hibernate-search-v5migrationhelper-engine-8.1.0.Alpha1.jar hibernate-search-v5migrationhelper-orm-8.1.0.Alpha1.pom hibernate-search-v5migrationhelper-orm-8.1.0.Alpha1.jar hibernate-search-processor-8.1.0.Alpha1.pom hibernate-search-processor-8.1.0.Alpha1.jar hibernate-search-backend-lucene-next-8.1.0.Alpha1.pom hibernate-search-backend-lucene-next-8.1.0.Alpha1.jar"
-koFiles="hibernate-search-platform-common-bom-8.1.0.Alpha1.pom"
+koFiles=""
 ignoredFiles=""
 reference_java_version="21 (from MANIFEST.MF Build-Jdk-Spec)"
 reference_os_name="Unix (from pom.properties newline)"
-# diffoscope target/reference/org.hibernate.search/hibernate-search-platform-common-bom-8.1.0.Alpha1.pom bom/platform-common/target/.flattened-pom.xml
-stabilize_ok=0
-stabilize_ko=0
-stabilize_ignored=1
-stabilize_okFiles=""
-stabilize_koFiles=""
-stabilize_ignoredFiles="hibernate-search-platform-common-bom-8.1.0.Alpha1.pom.stabilized"

--- a/content/org/hibernate/search/hibernate-search-bom/hibernate-search-parent-8.1.0.Alpha1.buildinfo
+++ b/content/org/hibernate/search/hibernate-search-bom/hibernate-search-parent-8.1.0.Alpha1.buildinfo
@@ -19,7 +19,7 @@ java.vendor=Ubuntu
 os.name=Linux
 
 # Maven rebuild instructions and effective environment
-mvn.version=3.9.6
+mvn.version=3.9.11
 mvn.aggregate.artifact-id=hibernate-search-backend-lucene-next
 
 # aggregated output
@@ -31,224 +31,217 @@ outputs.0.0.filename=hibernate-search-bom-8.1.0.Alpha1.pom
 outputs.0.0.length=9785
 outputs.0.0.checksums.sha512=6a173f2b0caf0d68ba85348f1db8908d46289211432d1fd5e0550dea65210ce4472d700319b1744974e9840c47bf3b69f2f17cebf5d527c4abdad8fea60772cb
 
-outputs.1.coordinates=org.hibernate.search:hibernate-search-platform-common-bom
+outputs.1.coordinates=org.hibernate.search:hibernate-search-platform-bom
 
 outputs.1.0.groupId=org.hibernate.search
-outputs.1.0.filename=hibernate-search-platform-common-bom-8.1.0.Alpha1.pom
-outputs.1.0.length=28182
-outputs.1.0.checksums.sha512=26746ed5f93d2e6acf34e3456ecf5dc4c614c87e7366c55a4ab3c48d5e25823410c9bab19091e6e89b77c419997aa1f6099dc5f80f1a30e21f2be9283addb9db
+outputs.1.0.filename=hibernate-search-platform-bom-8.1.0.Alpha1.pom
+outputs.1.0.length=137674
+outputs.1.0.checksums.sha512=9758705e76e9edd796c4a2a240122f1c799a0ff502e6310a70a0c16e4e548ecab060fc58d0bc03808c2ce5a71a5982e3b03e89710c1739e5bf16b59d11e2958d
 
-outputs.2.coordinates=org.hibernate.search:hibernate-search-platform-bom
+outputs.2.coordinates=org.hibernate.search:hibernate-search-platform-next-bom
 
 outputs.2.0.groupId=org.hibernate.search
-outputs.2.0.filename=hibernate-search-platform-bom-8.1.0.Alpha1.pom
-outputs.2.0.length=137674
-outputs.2.0.checksums.sha512=9758705e76e9edd796c4a2a240122f1c799a0ff502e6310a70a0c16e4e548ecab060fc58d0bc03808c2ce5a71a5982e3b03e89710c1739e5bf16b59d11e2958d
+outputs.2.0.filename=hibernate-search-platform-next-bom-8.1.0.Alpha1.pom
+outputs.2.0.length=137694
+outputs.2.0.checksums.sha512=5e11ab5c62b03b06934f608029cad563be816e390d297621a307457d7bcdd63c7c803bd495bfaf478c41a9c89b6e340e6ea5d1d2bec414bd475a51c27c29bf0e
 
-outputs.3.coordinates=org.hibernate.search:hibernate-search-platform-next-bom
+outputs.3.coordinates=org.hibernate.search:hibernate-search-util-common
 
 outputs.3.0.groupId=org.hibernate.search
-outputs.3.0.filename=hibernate-search-platform-next-bom-8.1.0.Alpha1.pom
-outputs.3.0.length=137694
-outputs.3.0.checksums.sha512=5e11ab5c62b03b06934f608029cad563be816e390d297621a307457d7bcdd63c7c803bd495bfaf478c41a9c89b6e340e6ea5d1d2bec414bd475a51c27c29bf0e
+outputs.3.0.filename=hibernate-search-util-common-8.1.0.Alpha1.pom
+outputs.3.0.length=4013
+outputs.3.0.checksums.sha512=d8050f957c7fc029c586abcc6fbb860068c4af7cf2a17527e7d7f1daab74fe185dface0d1c6852fa1c0d48edc0956a89aab61acdb530e174574174ba52e26c9e
 
-outputs.4.coordinates=org.hibernate.search:hibernate-search-util-common
+outputs.3.1.groupId=org.hibernate.search
+outputs.3.1.filename=hibernate-search-util-common-8.1.0.Alpha1.jar
+outputs.3.1.length=130614
+outputs.3.1.checksums.sha512=ff7d96540353c64ab55efc43e2b6cef475c91cca8224ee9082c67cf145c378a1710176a42a06d4e6461e213821f8d9f6e72d31507ac38dcf93e0396e9cd057ba
+
+outputs.4.coordinates=org.hibernate.search:hibernate-search-engine
 
 outputs.4.0.groupId=org.hibernate.search
-outputs.4.0.filename=hibernate-search-util-common-8.1.0.Alpha1.pom
-outputs.4.0.length=4013
-outputs.4.0.checksums.sha512=d8050f957c7fc029c586abcc6fbb860068c4af7cf2a17527e7d7f1daab74fe185dface0d1c6852fa1c0d48edc0956a89aab61acdb530e174574174ba52e26c9e
+outputs.4.0.filename=hibernate-search-engine-8.1.0.Alpha1.pom
+outputs.4.0.length=4045
+outputs.4.0.checksums.sha512=f3e687465c77a89f6458800ff66b09e94d68f4860a94da56763138f1b6f6dd378a3e84549b8705818d7d0665c70b8e2de7d9bcc433c50d9e3d5675d004d1b243
 
 outputs.4.1.groupId=org.hibernate.search
-outputs.4.1.filename=hibernate-search-util-common-8.1.0.Alpha1.jar
-outputs.4.1.length=130614
-outputs.4.1.checksums.sha512=ff7d96540353c64ab55efc43e2b6cef475c91cca8224ee9082c67cf145c378a1710176a42a06d4e6461e213821f8d9f6e72d31507ac38dcf93e0396e9cd057ba
+outputs.4.1.filename=hibernate-search-engine-8.1.0.Alpha1.jar
+outputs.4.1.length=1063611
+outputs.4.1.checksums.sha512=663af294aa7b34344a26c86f0a2f358205d7aa240a5b36e091300144a94078b674c2517d09890b4838d78376ad7ae236a9e3f8f9fa86c27eb0df0db715ab1611
 
-outputs.5.coordinates=org.hibernate.search:hibernate-search-engine
+outputs.5.coordinates=org.hibernate.search:hibernate-search-backend-lucene
 
 outputs.5.0.groupId=org.hibernate.search
-outputs.5.0.filename=hibernate-search-engine-8.1.0.Alpha1.pom
-outputs.5.0.length=4045
-outputs.5.0.checksums.sha512=f3e687465c77a89f6458800ff66b09e94d68f4860a94da56763138f1b6f6dd378a3e84549b8705818d7d0665c70b8e2de7d9bcc433c50d9e3d5675d004d1b243
+outputs.5.0.filename=hibernate-search-backend-lucene-8.1.0.Alpha1.pom
+outputs.5.0.length=5191
+outputs.5.0.checksums.sha512=bae2f2729767c7d8b90bc0cc3f1ac7015f5de53fd20a221dd444fd7a957247443c9d95bb4224a4b3cc3c5492950aa0e3b233e04e333fc4d1a2e3b7586844f4fc
 
 outputs.5.1.groupId=org.hibernate.search
-outputs.5.1.filename=hibernate-search-engine-8.1.0.Alpha1.jar
-outputs.5.1.length=1063611
-outputs.5.1.checksums.sha512=663af294aa7b34344a26c86f0a2f358205d7aa240a5b36e091300144a94078b674c2517d09890b4838d78376ad7ae236a9e3f8f9fa86c27eb0df0db715ab1611
+outputs.5.1.filename=hibernate-search-backend-lucene-8.1.0.Alpha1.jar
+outputs.5.1.length=1243193
+outputs.5.1.checksums.sha512=5b4b6e1a121d31fb3bc033cf3d0361b7c4de2bd8fc6538e5b7e9a880d2ab7d4d56d7f92b5186dcf67517d65dae548976514cdf25ff540980d34bff3a0173de31
 
-outputs.6.coordinates=org.hibernate.search:hibernate-search-backend-lucene
+outputs.6.coordinates=org.hibernate.search:hibernate-search-backend-elasticsearch
 
 outputs.6.0.groupId=org.hibernate.search
-outputs.6.0.filename=hibernate-search-backend-lucene-8.1.0.Alpha1.pom
-outputs.6.0.length=5191
-outputs.6.0.checksums.sha512=bae2f2729767c7d8b90bc0cc3f1ac7015f5de53fd20a221dd444fd7a957247443c9d95bb4224a4b3cc3c5492950aa0e3b233e04e333fc4d1a2e3b7586844f4fc
+outputs.6.0.filename=hibernate-search-backend-elasticsearch-8.1.0.Alpha1.pom
+outputs.6.0.length=4977
+outputs.6.0.checksums.sha512=b0c3671612241e3da3ff84ce100a2b507e8aea476929544583d405231fb7139c44814bd9586b0cb58b447ca348938be8a0381087b05468acb70dbc78d621d9ce
 
 outputs.6.1.groupId=org.hibernate.search
-outputs.6.1.filename=hibernate-search-backend-lucene-8.1.0.Alpha1.jar
-outputs.6.1.length=1243193
-outputs.6.1.checksums.sha512=5b4b6e1a121d31fb3bc033cf3d0361b7c4de2bd8fc6538e5b7e9a880d2ab7d4d56d7f92b5186dcf67517d65dae548976514cdf25ff540980d34bff3a0173de31
+outputs.6.1.filename=hibernate-search-backend-elasticsearch-8.1.0.Alpha1.jar
+outputs.6.1.length=1252655
+outputs.6.1.checksums.sha512=6d7f0a0bcf35eecf9517666e3a0fcd8f10666b94e4372ebfb9c5493e9d54d0f0f9828fb40d0f23fec690a5f52e3ad3b61837b5f45d2a70f76a7ecfdba0b38580
 
-outputs.7.coordinates=org.hibernate.search:hibernate-search-backend-elasticsearch
+outputs.7.coordinates=org.hibernate.search:hibernate-search-backend-elasticsearch-aws
 
 outputs.7.0.groupId=org.hibernate.search
-outputs.7.0.filename=hibernate-search-backend-elasticsearch-8.1.0.Alpha1.pom
-outputs.7.0.length=4977
-outputs.7.0.checksums.sha512=b0c3671612241e3da3ff84ce100a2b507e8aea476929544583d405231fb7139c44814bd9586b0cb58b447ca348938be8a0381087b05468acb70dbc78d621d9ce
+outputs.7.0.filename=hibernate-search-backend-elasticsearch-aws-8.1.0.Alpha1.pom
+outputs.7.0.length=4475
+outputs.7.0.checksums.sha512=8799120c68148b6656560d017cec74813d2a89215712eb78f8ffb77d3c2219b3bae899709cb0ba82ec68200c83c5c01073c46b7d72c018d665c22e8d910b0f8a
 
 outputs.7.1.groupId=org.hibernate.search
-outputs.7.1.filename=hibernate-search-backend-elasticsearch-8.1.0.Alpha1.jar
-outputs.7.1.length=1252655
-outputs.7.1.checksums.sha512=6d7f0a0bcf35eecf9517666e3a0fcd8f10666b94e4372ebfb9c5493e9d54d0f0f9828fb40d0f23fec690a5f52e3ad3b61837b5f45d2a70f76a7ecfdba0b38580
+outputs.7.1.filename=hibernate-search-backend-elasticsearch-aws-8.1.0.Alpha1.jar
+outputs.7.1.length=27565
+outputs.7.1.checksums.sha512=ea5b8573a784c6b1b4e903583277b9236dd80b29fe3be11ac2e7675068fb6d32c7f503c1daaa09366cd51b23da0ce47cb7f224d732fb22b2e62535c3061805ad
 
-outputs.8.coordinates=org.hibernate.search:hibernate-search-backend-elasticsearch-aws
+outputs.8.coordinates=org.hibernate.search:hibernate-search-mapper-pojo-base
 
 outputs.8.0.groupId=org.hibernate.search
-outputs.8.0.filename=hibernate-search-backend-elasticsearch-aws-8.1.0.Alpha1.pom
-outputs.8.0.length=4475
-outputs.8.0.checksums.sha512=8799120c68148b6656560d017cec74813d2a89215712eb78f8ffb77d3c2219b3bae899709cb0ba82ec68200c83c5c01073c46b7d72c018d665c22e8d910b0f8a
+outputs.8.0.filename=hibernate-search-mapper-pojo-base-8.1.0.Alpha1.pom
+outputs.8.0.length=4388
+outputs.8.0.checksums.sha512=8c31e4b090b1d35c681037c2747161a02644265a177cab9664b4aa7327894a7805a6469d6867272f28b147104b2ca3e8d19911a80e048a3038734120e3faeec4
 
 outputs.8.1.groupId=org.hibernate.search
-outputs.8.1.filename=hibernate-search-backend-elasticsearch-aws-8.1.0.Alpha1.jar
-outputs.8.1.length=27565
-outputs.8.1.checksums.sha512=ea5b8573a784c6b1b4e903583277b9236dd80b29fe3be11ac2e7675068fb6d32c7f503c1daaa09366cd51b23da0ce47cb7f224d732fb22b2e62535c3061805ad
+outputs.8.1.filename=hibernate-search-mapper-pojo-base-8.1.0.Alpha1.jar
+outputs.8.1.length=1195759
+outputs.8.1.checksums.sha512=bb21647e7c0b242a8305e13afe574d6e193424ddbde93b217c94dcf111474238a238da077a93ec27a8e26d0468ce0b54b91bbd9bb3dcb85b5348a819ed52ce23
 
-outputs.9.coordinates=org.hibernate.search:hibernate-search-mapper-pojo-base
+outputs.9.coordinates=org.hibernate.search:hibernate-search-mapper-pojo-standalone
 
 outputs.9.0.groupId=org.hibernate.search
-outputs.9.0.filename=hibernate-search-mapper-pojo-base-8.1.0.Alpha1.pom
-outputs.9.0.length=4388
-outputs.9.0.checksums.sha512=8c31e4b090b1d35c681037c2747161a02644265a177cab9664b4aa7327894a7805a6469d6867272f28b147104b2ca3e8d19911a80e048a3038734120e3faeec4
+outputs.9.0.filename=hibernate-search-mapper-pojo-standalone-8.1.0.Alpha1.pom
+outputs.9.0.length=4614
+outputs.9.0.checksums.sha512=670854cff788aa3b856c3b76a8968e4427141b388815af5b69f674315a378bf38fc57e00b1b545d272f2523c7981fb84e15601b5f7e21161cc98845f2083f514
 
 outputs.9.1.groupId=org.hibernate.search
-outputs.9.1.filename=hibernate-search-mapper-pojo-base-8.1.0.Alpha1.jar
-outputs.9.1.length=1195759
-outputs.9.1.checksums.sha512=bb21647e7c0b242a8305e13afe574d6e193424ddbde93b217c94dcf111474238a238da077a93ec27a8e26d0468ce0b54b91bbd9bb3dcb85b5348a819ed52ce23
+outputs.9.1.filename=hibernate-search-mapper-pojo-standalone-8.1.0.Alpha1.jar
+outputs.9.1.length=157320
+outputs.9.1.checksums.sha512=5a5c7f5b12c60546f8fb075fd7b000c81b4f0db6954e8294e4939279536047aa87b010ea3f4bd1fb0b638903a55077017faceae4203db87ed90adf66081726d5
 
-outputs.10.coordinates=org.hibernate.search:hibernate-search-mapper-pojo-standalone
+outputs.10.coordinates=org.hibernate.search:hibernate-search-mapper-orm
 
 outputs.10.0.groupId=org.hibernate.search
-outputs.10.0.filename=hibernate-search-mapper-pojo-standalone-8.1.0.Alpha1.pom
-outputs.10.0.length=4614
-outputs.10.0.checksums.sha512=670854cff788aa3b856c3b76a8968e4427141b388815af5b69f674315a378bf38fc57e00b1b545d272f2523c7981fb84e15601b5f7e21161cc98845f2083f514
+outputs.10.0.filename=hibernate-search-mapper-orm-8.1.0.Alpha1.pom
+outputs.10.0.length=5805
+outputs.10.0.checksums.sha512=0c2947bea5df2ef67b1488732af418d203b276cf281eeca1f3369f87d094a7532bd68192c59dea892bb807157b5ca3790d038b91ec23cd9a93833d45e6dec60b
 
 outputs.10.1.groupId=org.hibernate.search
-outputs.10.1.filename=hibernate-search-mapper-pojo-standalone-8.1.0.Alpha1.jar
-outputs.10.1.length=157320
-outputs.10.1.checksums.sha512=5a5c7f5b12c60546f8fb075fd7b000c81b4f0db6954e8294e4939279536047aa87b010ea3f4bd1fb0b638903a55077017faceae4203db87ed90adf66081726d5
+outputs.10.1.filename=hibernate-search-mapper-orm-8.1.0.Alpha1.jar
+outputs.10.1.length=373391
+outputs.10.1.checksums.sha512=ee62cb3261a300fff01f3530d6406cff9354fcbe857a5537aa430c680e3058d2822693a2ec52b2e844be7833ac246b7778a71c1a7069245446efcaed5bcb4491
 
-outputs.11.coordinates=org.hibernate.search:hibernate-search-mapper-orm
+outputs.11.coordinates=org.hibernate.search:hibernate-search-mapper-orm-outbox-polling
 
 outputs.11.0.groupId=org.hibernate.search
-outputs.11.0.filename=hibernate-search-mapper-orm-8.1.0.Alpha1.pom
-outputs.11.0.length=5805
-outputs.11.0.checksums.sha512=0c2947bea5df2ef67b1488732af418d203b276cf281eeca1f3369f87d094a7532bd68192c59dea892bb807157b5ca3790d038b91ec23cd9a93833d45e6dec60b
+outputs.11.0.filename=hibernate-search-mapper-orm-outbox-polling-8.1.0.Alpha1.pom
+outputs.11.0.length=5093
+outputs.11.0.checksums.sha512=297e592a5ecfae0f7de71d6b5251fecb08dc5c0854702d7bd7e8d8c9e89a5c79ca198436501e8769a90edade2e36c65363e7d73199fd5d2fec2bc1394af2c985
 
 outputs.11.1.groupId=org.hibernate.search
-outputs.11.1.filename=hibernate-search-mapper-orm-8.1.0.Alpha1.jar
-outputs.11.1.length=373391
-outputs.11.1.checksums.sha512=ee62cb3261a300fff01f3530d6406cff9354fcbe857a5537aa430c680e3058d2822693a2ec52b2e844be7833ac246b7778a71c1a7069245446efcaed5bcb4491
+outputs.11.1.filename=hibernate-search-mapper-orm-outbox-polling-8.1.0.Alpha1.jar
+outputs.11.1.length=221677
+outputs.11.1.checksums.sha512=4e0d35d0fd07ce8f6ff538b593d189e2a67f9fef73ab7a9b02ad25e015078e09ba47e9e6c216a269bfece112b8b832b7266d59f3aa0e601e39fc2a70a15c894a
 
-outputs.12.coordinates=org.hibernate.search:hibernate-search-mapper-orm-outbox-polling
+outputs.12.coordinates=org.hibernate.search:hibernate-search-mapper-orm-coordination-outbox-polling
 
 outputs.12.0.groupId=org.hibernate.search
-outputs.12.0.filename=hibernate-search-mapper-orm-outbox-polling-8.1.0.Alpha1.pom
-outputs.12.0.length=5093
-outputs.12.0.checksums.sha512=297e592a5ecfae0f7de71d6b5251fecb08dc5c0854702d7bd7e8d8c9e89a5c79ca198436501e8769a90edade2e36c65363e7d73199fd5d2fec2bc1394af2c985
+outputs.12.0.filename=hibernate-search-mapper-orm-coordination-outbox-polling-8.1.0.Alpha1.pom
+outputs.12.0.length=5951
+outputs.12.0.checksums.sha512=69fc61a51c0feccbec53d56b8ba89591ec1923c7c81a236661a2ef96656b0d0099d1b720297df39d2c907d0da2ad787a2027273fadfb217057e49b4cfca547b7
 
-outputs.12.1.groupId=org.hibernate.search
-outputs.12.1.filename=hibernate-search-mapper-orm-outbox-polling-8.1.0.Alpha1.jar
-outputs.12.1.length=221677
-outputs.12.1.checksums.sha512=4e0d35d0fd07ce8f6ff538b593d189e2a67f9fef73ab7a9b02ad25e015078e09ba47e9e6c216a269bfece112b8b832b7266d59f3aa0e601e39fc2a70a15c894a
-
-outputs.13.coordinates=org.hibernate.search:hibernate-search-mapper-orm-coordination-outbox-polling
+outputs.13.coordinates=org.hibernate.search:hibernate-search-mapper-orm-batch-jsr352-core
 
 outputs.13.0.groupId=org.hibernate.search
-outputs.13.0.filename=hibernate-search-mapper-orm-coordination-outbox-polling-8.1.0.Alpha1.pom
-outputs.13.0.length=5951
-outputs.13.0.checksums.sha512=69fc61a51c0feccbec53d56b8ba89591ec1923c7c81a236661a2ef96656b0d0099d1b720297df39d2c907d0da2ad787a2027273fadfb217057e49b4cfca547b7
+outputs.13.0.filename=hibernate-search-mapper-orm-batch-jsr352-core-8.1.0.Alpha1.pom
+outputs.13.0.length=5907
+outputs.13.0.checksums.sha512=0ccdf7d7bf2a58bd6230268dc5450197ef2a6a3ece3290d97b72ef2030174c05b54b39b5074d9a630e9e1e174b15c57c59aa80ee96ca718d5b7f8504de386596
 
-outputs.14.coordinates=org.hibernate.search:hibernate-search-mapper-orm-batch-jsr352-core
+outputs.14.coordinates=org.hibernate.search:hibernate-search-mapper-orm-batch-jsr352-jberet
 
 outputs.14.0.groupId=org.hibernate.search
-outputs.14.0.filename=hibernate-search-mapper-orm-batch-jsr352-core-8.1.0.Alpha1.pom
-outputs.14.0.length=5907
-outputs.14.0.checksums.sha512=0ccdf7d7bf2a58bd6230268dc5450197ef2a6a3ece3290d97b72ef2030174c05b54b39b5074d9a630e9e1e174b15c57c59aa80ee96ca718d5b7f8504de386596
+outputs.14.0.filename=hibernate-search-mapper-orm-batch-jsr352-jberet-8.1.0.Alpha1.pom
+outputs.14.0.length=5914
+outputs.14.0.checksums.sha512=a09df366c8adea5fd7f366e23fcb35f0c7374ba1b3522e307df56836369ff5d4f988f16ad5b3b9339234948c974c180b85403dc831f718527ca063429d8e4d22
 
-outputs.15.coordinates=org.hibernate.search:hibernate-search-mapper-orm-batch-jsr352-jberet
+outputs.15.coordinates=org.hibernate.search:hibernate-search-mapper-orm-jakarta-batch-core
 
 outputs.15.0.groupId=org.hibernate.search
-outputs.15.0.filename=hibernate-search-mapper-orm-batch-jsr352-jberet-8.1.0.Alpha1.pom
-outputs.15.0.length=5914
-outputs.15.0.checksums.sha512=a09df366c8adea5fd7f366e23fcb35f0c7374ba1b3522e307df56836369ff5d4f988f16ad5b3b9339234948c974c180b85403dc831f718527ca063429d8e4d22
+outputs.15.0.filename=hibernate-search-mapper-orm-jakarta-batch-core-8.1.0.Alpha1.pom
+outputs.15.0.length=4966
+outputs.15.0.checksums.sha512=79d1262e0caf81bc50bb1f30b4ff956621cad778c8bc3797516bb6a80957378ffc849f7c4d105e74a7547eb1ddae5d71e1c15ccdb0b45ad328e61b03ded9b3e4
 
-outputs.16.coordinates=org.hibernate.search:hibernate-search-mapper-orm-jakarta-batch-core
+outputs.15.1.groupId=org.hibernate.search
+outputs.15.1.filename=hibernate-search-mapper-orm-jakarta-batch-core-8.1.0.Alpha1.jar
+outputs.15.1.length=85241
+outputs.15.1.checksums.sha512=7aeac8e03b8d04eba2271eba070bc802ded22ef80d60c0647433accf89317005295594e15ee7d8414298dc7723ec8ab24af9093b576240505cc52d490f0599a9
+
+outputs.16.coordinates=org.hibernate.search:hibernate-search-mapper-orm-jakarta-batch-jberet
 
 outputs.16.0.groupId=org.hibernate.search
-outputs.16.0.filename=hibernate-search-mapper-orm-jakarta-batch-core-8.1.0.Alpha1.pom
-outputs.16.0.length=4966
-outputs.16.0.checksums.sha512=79d1262e0caf81bc50bb1f30b4ff956621cad778c8bc3797516bb6a80957378ffc849f7c4d105e74a7547eb1ddae5d71e1c15ccdb0b45ad328e61b03ded9b3e4
+outputs.16.0.filename=hibernate-search-mapper-orm-jakarta-batch-jberet-8.1.0.Alpha1.pom
+outputs.16.0.length=5239
+outputs.16.0.checksums.sha512=d53c4efa16c3490251922702355ce6cfd2c117c01fb69c33c237373c1e4c0890359f109345e3a9566eb990125541acadd856ff574daf8175c28f9a51b60ef8af
 
 outputs.16.1.groupId=org.hibernate.search
-outputs.16.1.filename=hibernate-search-mapper-orm-jakarta-batch-core-8.1.0.Alpha1.jar
-outputs.16.1.length=85241
-outputs.16.1.checksums.sha512=7aeac8e03b8d04eba2271eba070bc802ded22ef80d60c0647433accf89317005295594e15ee7d8414298dc7723ec8ab24af9093b576240505cc52d490f0599a9
+outputs.16.1.filename=hibernate-search-mapper-orm-jakarta-batch-jberet-8.1.0.Alpha1.jar
+outputs.16.1.length=19816
+outputs.16.1.checksums.sha512=930adc55949944ab3a8864736dfc4034f3177284c0351337ddd01121ef28a681acf5bafda2aa3f7dea84326c160cc7e1ff66ad70754bee73af579a90aa8ebe03
 
-outputs.17.coordinates=org.hibernate.search:hibernate-search-mapper-orm-jakarta-batch-jberet
+outputs.17.coordinates=org.hibernate.search:hibernate-search-v5migrationhelper-engine
 
 outputs.17.0.groupId=org.hibernate.search
-outputs.17.0.filename=hibernate-search-mapper-orm-jakarta-batch-jberet-8.1.0.Alpha1.pom
-outputs.17.0.length=5239
-outputs.17.0.checksums.sha512=d53c4efa16c3490251922702355ce6cfd2c117c01fb69c33c237373c1e4c0890359f109345e3a9566eb990125541acadd856ff574daf8175c28f9a51b60ef8af
+outputs.17.0.filename=hibernate-search-v5migrationhelper-engine-8.1.0.Alpha1.pom
+outputs.17.0.length=4698
+outputs.17.0.checksums.sha512=6fc88f570bb918d4002a5afca6c81f2060730f8373e717a20c9b69aba1f4bdb5ba15bff5e497c0bbf7b097093fbf114a6060a5a2e2025522989ed2c3a91ac143
 
 outputs.17.1.groupId=org.hibernate.search
-outputs.17.1.filename=hibernate-search-mapper-orm-jakarta-batch-jberet-8.1.0.Alpha1.jar
-outputs.17.1.length=19816
-outputs.17.1.checksums.sha512=930adc55949944ab3a8864736dfc4034f3177284c0351337ddd01121ef28a681acf5bafda2aa3f7dea84326c160cc7e1ff66ad70754bee73af579a90aa8ebe03
+outputs.17.1.filename=hibernate-search-v5migrationhelper-engine-8.1.0.Alpha1.jar
+outputs.17.1.length=206249
+outputs.17.1.checksums.sha512=f115a24be52e72681e56cc28cf637c9e1ad58e001fd5dbc8b1f33bf483a0d26a0e2802436e1ebf638924c40522dfba8d2542f545fc78b15c4442259de200e855
 
-outputs.18.coordinates=org.hibernate.search:hibernate-search-v5migrationhelper-engine
+outputs.18.coordinates=org.hibernate.search:hibernate-search-v5migrationhelper-orm
 
 outputs.18.0.groupId=org.hibernate.search
-outputs.18.0.filename=hibernate-search-v5migrationhelper-engine-8.1.0.Alpha1.pom
-outputs.18.0.length=4698
-outputs.18.0.checksums.sha512=6fc88f570bb918d4002a5afca6c81f2060730f8373e717a20c9b69aba1f4bdb5ba15bff5e497c0bbf7b097093fbf114a6060a5a2e2025522989ed2c3a91ac143
+outputs.18.0.filename=hibernate-search-v5migrationhelper-orm-8.1.0.Alpha1.pom
+outputs.18.0.length=4099
+outputs.18.0.checksums.sha512=ff984146cb86f14ff58831e5b55277c8ee2bd005285cdb75eedbf7d63c1c85c0bc08fa39cedab2973d4e5e71f917a58f1867ca9c34372f5feffca0b83b09a134
 
 outputs.18.1.groupId=org.hibernate.search
-outputs.18.1.filename=hibernate-search-v5migrationhelper-engine-8.1.0.Alpha1.jar
-outputs.18.1.length=206249
-outputs.18.1.checksums.sha512=f115a24be52e72681e56cc28cf637c9e1ad58e001fd5dbc8b1f33bf483a0d26a0e2802436e1ebf638924c40522dfba8d2542f545fc78b15c4442259de200e855
+outputs.18.1.filename=hibernate-search-v5migrationhelper-orm-8.1.0.Alpha1.jar
+outputs.18.1.length=37773
+outputs.18.1.checksums.sha512=0e051820f70f11fb5d3e78ca74f0a0e081d4d4b2be7b5dfada03a3ca1260d0e0913855a36b3a92c5441c9b801d39ab81f9198f6730868e9b2f829978315715d6
 
-outputs.19.coordinates=org.hibernate.search:hibernate-search-v5migrationhelper-orm
+outputs.19.coordinates=org.hibernate.search:hibernate-search-processor
 
 outputs.19.0.groupId=org.hibernate.search
-outputs.19.0.filename=hibernate-search-v5migrationhelper-orm-8.1.0.Alpha1.pom
-outputs.19.0.length=4099
-outputs.19.0.checksums.sha512=ff984146cb86f14ff58831e5b55277c8ee2bd005285cdb75eedbf7d63c1c85c0bc08fa39cedab2973d4e5e71f917a58f1867ca9c34372f5feffca0b83b09a134
+outputs.19.0.filename=hibernate-search-processor-8.1.0.Alpha1.pom
+outputs.19.0.length=4732
+outputs.19.0.checksums.sha512=137c112500591000c5c1773d04744c474cb24a5457594f7a8f60a5c2dd20e5e2ca456d36024252a428670729dc909261f7cdddae5c1120bd1fc67e70ce3fd2a0
 
 outputs.19.1.groupId=org.hibernate.search
-outputs.19.1.filename=hibernate-search-v5migrationhelper-orm-8.1.0.Alpha1.jar
-outputs.19.1.length=37773
-outputs.19.1.checksums.sha512=0e051820f70f11fb5d3e78ca74f0a0e081d4d4b2be7b5dfada03a3ca1260d0e0913855a36b3a92c5441c9b801d39ab81f9198f6730868e9b2f829978315715d6
+outputs.19.1.filename=hibernate-search-processor-8.1.0.Alpha1.jar
+outputs.19.1.length=117057
+outputs.19.1.checksums.sha512=29ce8600b425ea1f8d0cf38f36a1fd5ca27472ae4fbfd9399bc0b5729ee6024f01eb0762fd305cf313ce8c5162c305fd3dc1882f81b4e954f23dcdf4a2dbdbc9
 
-outputs.20.coordinates=org.hibernate.search:hibernate-search-processor
+outputs.20.coordinates=org.hibernate.search:hibernate-search-backend-lucene-next
 
 outputs.20.0.groupId=org.hibernate.search
-outputs.20.0.filename=hibernate-search-processor-8.1.0.Alpha1.pom
-outputs.20.0.length=4732
-outputs.20.0.checksums.sha512=137c112500591000c5c1773d04744c474cb24a5457594f7a8f60a5c2dd20e5e2ca456d36024252a428670729dc909261f7cdddae5c1120bd1fc67e70ce3fd2a0
+outputs.20.0.filename=hibernate-search-backend-lucene-next-8.1.0.Alpha1.pom
+outputs.20.0.length=5205
+outputs.20.0.checksums.sha512=ca04cc9304fbb922c73a357f8b9629b9c611779e3c574f7744a58e6835047e8885871f361c7a9f9138cd29f3522baff0ef10af52066bb78342ff1f5710375433
 
 outputs.20.1.groupId=org.hibernate.search
-outputs.20.1.filename=hibernate-search-processor-8.1.0.Alpha1.jar
-outputs.20.1.length=117057
-outputs.20.1.checksums.sha512=29ce8600b425ea1f8d0cf38f36a1fd5ca27472ae4fbfd9399bc0b5729ee6024f01eb0762fd305cf313ce8c5162c305fd3dc1882f81b4e954f23dcdf4a2dbdbc9
-
-outputs.21.coordinates=org.hibernate.search:hibernate-search-backend-lucene-next
-
-outputs.21.0.groupId=org.hibernate.search
-outputs.21.0.filename=hibernate-search-backend-lucene-next-8.1.0.Alpha1.pom
-outputs.21.0.length=5205
-outputs.21.0.checksums.sha512=ca04cc9304fbb922c73a357f8b9629b9c611779e3c574f7744a58e6835047e8885871f361c7a9f9138cd29f3522baff0ef10af52066bb78342ff1f5710375433
-
-outputs.21.1.groupId=org.hibernate.search
-outputs.21.1.filename=hibernate-search-backend-lucene-next-8.1.0.Alpha1.jar
-outputs.21.1.length=1249556
-outputs.21.1.checksums.sha512=09b9fbb133018a4ebe7d799ccac44996c115078eda019aca6a1cb90b0693fb374df6462f19f38aff8edcee2ac00eba083b46d4af75eecf8411ec90ca57fbb508
+outputs.20.1.filename=hibernate-search-backend-lucene-next-8.1.0.Alpha1.jar
+outputs.20.1.length=1249556
+outputs.20.1.checksums.sha512=09b9fbb133018a4ebe7d799ccac44996c115078eda019aca6a1cb90b0693fb374df6462f19f38aff8edcee2ac00eba083b46d4af75eecf8411ec90ca57fbb508

--- a/content/org/hibernate/search/hibernate-search-bom/hibernate-search-parent-8.1.0.Alpha1.buildspec
+++ b/content/org/hibernate/search/hibernate-search-bom/hibernate-search-parent-8.1.0.Alpha1.buildspec
@@ -11,22 +11,13 @@ gitRepo=https://github.com/hibernate/hibernate-search.git
 gitTag=${version}
 
 # Rebuild environment prerequisites
-tool=mvn-3.9.6
+tool=mvn-3.9.11
 jdk=21
 newline=lf
 workdir=/var/lib/jenkins/workspace/hibernate-search-release_main
 
 # Rebuild command
-#
-# NOTE: automatic skip detection is disabled for this command.
-# this is done so as Hibernate Search build explicitly disables
-# the maven-deploy-plugin by adding <skip> to its configuration.
-#
-# And while the nexus plugin is used for deployment and picks which modules to deploy,
-# maven-artifact-plugin will see the skip from the deploy plugin and ignore all modules.
-#
-# Hence, the explicit list of modules to skip:
-command="mvn clean package -Pskip-checks -DskipTests -Dmaven.javadoc.skip -Dgpg.skip -Dno-build-cache -Dbuildinfo.detect.skip=false -Dbuildinfo.skipModules='**/**internal**,**/**integrationtest**,**/**parent**,**/**documentation**,**/**reports**,**/**build**'"
+command="mvn clean package -Pskip-checks -DskipTests -Dmaven.javadoc.skip -Dgpg.skip -Dno-build-cache"
 
 # Location of the buildinfo file generated during rebuild (by artifact:compare for Maven) to record output fingerprints:
 buildinfo=target/hibernate-search-parent-${version}.buildinfo


### PR DESCRIPTION
Hey 🙂 👋🏻 
Here's an update to the Hibernate Search build spec. Current one picks up a pom that is not actually published (and shouldn't be).

- Use newer Maven (though the build is using wrapper, but as the spec file is modified .. let's bump it)
- Remove the now unnecessary disabling skip detection, with the move to Maven Central the nexus plugin is not used anymore, instead, the deploy plugin is used and the artifacts will be correctly detected.