### PR TITLE
Removes UMASK environment variable from Maven settings.xml

### DIFF
--- a/m2/settings.xml
+++ b/m2/settings.xml
@@ -1,5 +1,5 @@
 <settings>
-  <localRepository>${user.home}/.m2/repository-${MVN_UMASK}</localRepository>
+  <localRepository>${user.home}/.m2/repository</localRepository>
   <profiles>
     <profile>
       <id>staged-releases</id>


### PR DESCRIPTION
Apache Maven 4.0.0-rc-4 fails with:
> [ERROR] Internal error: java.lang.IllegalArgumentException: Invalid LocalRepositories: [/var/maven/.m2/repository-${MVN_UMASK} ()] -> [Help 1]
org.apache.maven.InternalErrorException: Internal error: java.lang.IllegalArgumentException: Invalid LocalRepositories: [/var/maven/.m2/repository-${MVN_UMASK} ()]
>     Suppressed: java.lang.IllegalArgumentException: Not fully interpolated local repository /var/maven/.m2/repository-${MVN_UMASK} ()

fixes #3135 