### PR TITLE
maven-metadata.xml fetching should not succeed in case of HTTP 404

### DIFF
--- a/bin/includes/fetchSource.sh
+++ b/bin/includes/fetchSource.sh
@@ -23,7 +23,7 @@ then
   info "Fetching maven-metadata.xml from Maven Central"
   metaUrl="https://repo.maven.apache.org/maven2/$(echo ${groupId} | tr '.' '/')/${artifactId}/maven-metadata.xml"
   echo -e "downloading \033[1m${metaUrl}\033[0m to $(pwd)"
-  runcommand curl -s $metaUrl --output maven-metadata.xml || fatal "failed to download maven-metadata.xml"
+  runcommand curl -s --fail $metaUrl --output maven-metadata.xml || fatal "failed to download maven-metadata.xml"
   head -15 maven-metadata.xml
 fi
 


### PR DESCRIPTION
While working on #4895 I stepped on the problem https://github.com/jvm-repo-rebuild/reproducible-central/pull/4895#discussion_r2691082737 that seems to be described in #111

Note that while `--fail` curl option is not available in old curl versions, it is already used in other places - for example
https://github.com/jvm-repo-rebuild/reproducible-central/blob/cf7a583850aad684bd6ae2955f40da2961bf19a2/bin/wip.sh#L19-L21

---

Closes #111 