### PR TITLE
Switch to JDK 25 for building Hibernate Models

### DIFF
--- a/content/org/hibernate/models/hibernate-models/README.md
+++ b/content/org/hibernate/models/hibernate-models/README.md
@@ -15,13 +15,12 @@ Source code: [https://github.com/hibernate/hibernate-models.git](https://github.
 </details>
 
 rebuilding **10 releases** of org.hibernate.models:hibernate-models:
-- **7** releases were found successfully **fully reproducible** (100% reproducible artifacts :white_check_mark:),
-- 3 had issues (some unreproducible artifacts :warning:, see eventual :mag: diffoscope and/or :memo: issue tracker links):
-  - running [stabilize](doc/stabilize.md) on 1, 0 had all their differences removed :recycle:, 1 still had differences :rotating_light: or files not supported by stabilize :no_entry_sign:
+- **8** releases were found successfully **fully reproducible** (100% reproducible artifacts :white_check_mark:),
+- 2 had issues (some unreproducible artifacts :warning:, see eventual :mag: diffoscope and/or :memo: issue tracker links):
 
 | version | [build spec](/BUILDSPEC.md) | [result](https://reproducible-builds.org/docs/jvm/): reproducible? | [stabilize](https://github.com/google/oss-rebuild/blob/main/cmd/stabilize/README.md) | size |
 | -- | --------- | ------ | ------ | -- |
-| [1.1.1](https://central.sonatype.com/artifact/org.hibernate.models/hibernate-models/1.1.1/pom) | [gradle jdk25](hibernate-models-1.1.1.buildspec) | [result](hibernate-models-1.1.1.buildinfo): [8 :white_check_mark:  1 :warning:](hibernate-models-1.1.1.buildcompare) | 1 :rotating_light: | 566K |
+| [1.1.1](https://central.sonatype.com/artifact/org.hibernate.models/hibernate-models/1.1.1/pom) | [gradle jdk25](hibernate-models-1.1.1.buildspec) | [result](hibernate-models-1.1.1.buildinfo): [9 :white_check_mark: ](hibernate-models-1.1.1.buildcompare) | | 566K |
 | [1.1.0](https://central.sonatype.com/artifact/org.hibernate.models/hibernate-models/1.1.0/pom) | [gradle jdk25](hibernate-models-1.1.0.buildspec) | [result](hibernate-models-1.1.0.buildinfo): [9 :white_check_mark: ](hibernate-models-1.1.0.buildcompare) | | 566K |
 | [1.0.1](https://central.sonatype.com/artifact/org.hibernate.models/hibernate-models/1.0.1/pom) | [gradle jdk21](hibernate-models-1.0.1.buildspec) | [result](hibernate-models-1.0.1.buildinfo): [9 :white_check_mark: ](hibernate-models-1.0.1.buildcompare) | | 553K |
 | [1.0.0](https://central.sonatype.com/artifact/org.hibernate.models/hibernate-models/1.0.0/pom) | [gradle jdk21](hibernate-models-1.0.0.buildspec) | [result](hibernate-models-1.0.0.buildinfo): [9 :white_check_mark: ](hibernate-models-1.0.0.buildcompare) | | 552K |

--- a/content/org/hibernate/models/hibernate-models/README.md
+++ b/content/org/hibernate/models/hibernate-models/README.md
@@ -15,14 +15,14 @@ Source code: [https://github.com/hibernate/hibernate-models.git](https://github.
 </details>
 
 rebuilding **10 releases** of org.hibernate.models:hibernate-models:
-- **6** releases were found successfully **fully reproducible** (100% reproducible artifacts :white_check_mark:),
-- 4 had issues (some unreproducible artifacts :warning:, see eventual :mag: diffoscope and/or :memo: issue tracker links):
-  - running [stabilize](doc/stabilize.md) on 2, 0 had all their differences removed :recycle:, 2 still had differences :rotating_light: or files not supported by stabilize :no_entry_sign:
+- **7** releases were found successfully **fully reproducible** (100% reproducible artifacts :white_check_mark:),
+- 3 had issues (some unreproducible artifacts :warning:, see eventual :mag: diffoscope and/or :memo: issue tracker links):
+  - running [stabilize](doc/stabilize.md) on 1, 0 had all their differences removed :recycle:, 1 still had differences :rotating_light: or files not supported by stabilize :no_entry_sign:
 
 | version | [build spec](/BUILDSPEC.md) | [result](https://reproducible-builds.org/docs/jvm/): reproducible? | [stabilize](https://github.com/google/oss-rebuild/blob/main/cmd/stabilize/README.md) | size |
 | -- | --------- | ------ | ------ | -- |
-| [1.1.1](https://central.sonatype.com/artifact/org.hibernate.models/hibernate-models/1.1.1/pom) | [gradle jdk21](hibernate-models-1.1.1.buildspec) | [result](hibernate-models-1.1.1.buildinfo): [8 :white_check_mark:  1 :warning:](hibernate-models-1.1.1.buildcompare) | 1 :rotating_light: | 566K |
-| [1.1.0](https://central.sonatype.com/artifact/org.hibernate.models/hibernate-models/1.1.0/pom) | [gradle jdk21](hibernate-models-1.1.0.buildspec) | [result](hibernate-models-1.1.0.buildinfo): [8 :white_check_mark:  1 :warning:](hibernate-models-1.1.0.buildcompare) | 1 :rotating_light: | 566K |
+| [1.1.1](https://central.sonatype.com/artifact/org.hibernate.models/hibernate-models/1.1.1/pom) | [gradle jdk25](hibernate-models-1.1.1.buildspec) | [result](hibernate-models-1.1.1.buildinfo): [8 :white_check_mark:  1 :warning:](hibernate-models-1.1.1.buildcompare) | 1 :rotating_light: | 566K |
+| [1.1.0](https://central.sonatype.com/artifact/org.hibernate.models/hibernate-models/1.1.0/pom) | [gradle jdk25](hibernate-models-1.1.0.buildspec) | [result](hibernate-models-1.1.0.buildinfo): [9 :white_check_mark: ](hibernate-models-1.1.0.buildcompare) | | 566K |
 | [1.0.1](https://central.sonatype.com/artifact/org.hibernate.models/hibernate-models/1.0.1/pom) | [gradle jdk21](hibernate-models-1.0.1.buildspec) | [result](hibernate-models-1.0.1.buildinfo): [9 :white_check_mark: ](hibernate-models-1.0.1.buildcompare) | | 553K |
 | [1.0.0](https://central.sonatype.com/artifact/org.hibernate.models/hibernate-models/1.0.0/pom) | [gradle jdk21](hibernate-models-1.0.0.buildspec) | [result](hibernate-models-1.0.0.buildinfo): [9 :white_check_mark: ](hibernate-models-1.0.0.buildcompare) | | 552K |
 | [1.0.0.CR3](https://central.sonatype.com/artifact/org.hibernate.models/hibernate-models/1.0.0.CR3/pom) | [gradle jdk21](hibernate-models-1.0.0.CR3.buildspec) | [result](hibernate-models-1.0.0.CR3.buildinfo): [9 :white_check_mark: ](hibernate-models-1.0.0.CR3.buildcompare) | | 552K |

--- a/content/org/hibernate/models/hibernate-models/badge.json
+++ b/content/org/hibernate/models/hibernate-models/badge.json
@@ -1,6 +1,6 @@
 { "schemaVersion": 1,
   "label": "Reproducible Builds",
   "labelColor": "1e5b96",
-  "message": "8/9",
-  "color": "yellow",
+  "message": "9/9",
+  "color": "green",
   "isError": "true" }

--- a/content/org/hibernate/models/hibernate-models/hibernate-models-1.1.0.buildcompare
+++ b/content/org/hibernate/models/hibernate-models/hibernate-models-1.1.0.buildcompare
@@ -1,12 +1,5 @@
 version=1.1.0
-ok=8
-ko=1
-okFiles="hibernate-models-bytebuddy-1.1.0-sources.jar hibernate-models-bytebuddy-1.1.0.jar hibernate-models-bytebuddy-1.1.0.pom hibernate-models-jandex-1.1.0-sources.jar hibernate-models-jandex-1.1.0.jar hibernate-models-jandex-1.1.0.pom hibernate-models-1.1.0-sources.jar hibernate-models-1.1.0.pom"
-koFiles="hibernate-models-1.1.0.jar"
-# diffoscope central/org/hibernate/models/hibernate-models/1.1.0/hibernate-models-1.1.0.jar repository/org/hibernate/models/hibernate-models/1.1.0/hibernate-models-1.1.0.jar
-stabilize_ok=0
-stabilize_ko=1
-stabilize_ignored=0
-stabilize_okFiles=""
-stabilize_koFiles="hibernate-models-1.1.0.jar.stabilized"
-stabilize_ignoredFiles=""
+ok=9
+ko=0
+okFiles="hibernate-models-bytebuddy-1.1.0-sources.jar hibernate-models-bytebuddy-1.1.0.jar hibernate-models-bytebuddy-1.1.0.pom hibernate-models-jandex-1.1.0-sources.jar hibernate-models-jandex-1.1.0.jar hibernate-models-jandex-1.1.0.pom hibernate-models-1.1.0-sources.jar hibernate-models-1.1.0.jar hibernate-models-1.1.0.pom"
+koFiles=""

--- a/content/org/hibernate/models/hibernate-models/hibernate-models-1.1.0.buildinfo
+++ b/content/org/hibernate/models/hibernate-models/hibernate-models-1.1.0.buildinfo
@@ -3,7 +3,7 @@ group-id=org.hibernate.models
 artifact-id=hibernate-models
 
 build-tool=gradle
-java.version=21
+java.version=25
 os.name=lf
 
 outputs.1.coordinates=org.hibernate.models:hibernate-models-bytebuddy
@@ -43,8 +43,8 @@ outputs.3.0.length=134954
 outputs.3.0.checksums.sha512=5c6a2f82c6a9cc035a38e09d6dc5c125f00267e3b6485e8510d67accfbe9b3712f094333a51bba3e383eda56e577ec1d8f3cfaf098e88ecb309bc9dc9173e1d8
 
 outputs.3.1.filename=hibernate-models-1.1.0.jar
-outputs.3.1.length=222562
-outputs.3.1.checksums.sha512=2605af5a0c7cdc0f3635288998407f5fa1dc5a5db32052e5246bd9574ea937b57f0ce6a0618fa83b97ef50562f2ecda19c1e0e5d20f91d7195ff47824cae3d58
+outputs.3.1.length=222526
+outputs.3.1.checksums.sha512=781ff85372693dfee4f3c060af2ac8de4abb49100f5e6b9b559553f5b464b71cce03732fecc43cbd8f852de392178f24a36d0b4993f9999eda1393471688ac8c
 
 outputs.3.2.filename=hibernate-models-1.1.0.pom
 outputs.3.2.length=2116

--- a/content/org/hibernate/models/hibernate-models/hibernate-models-1.1.0.buildspec
+++ b/content/org/hibernate/models/hibernate-models/hibernate-models-1.1.0.buildspec
@@ -13,7 +13,7 @@ gitTag=${version}
 
 # Rebuild environment prerequisites
 tool=gradle
-jdk=21
+jdk=25
 newline=lf
 umask=022
 

--- a/content/org/hibernate/models/hibernate-models/hibernate-models-1.1.1.buildcompare
+++ b/content/org/hibernate/models/hibernate-models/hibernate-models-1.1.1.buildcompare
@@ -1,12 +1,5 @@
 version=1.1.1
-ok=8
-ko=1
-okFiles="hibernate-models-bytebuddy-1.1.1-sources.jar hibernate-models-bytebuddy-1.1.1.jar hibernate-models-bytebuddy-1.1.1.pom hibernate-models-jandex-1.1.1-sources.jar hibernate-models-jandex-1.1.1.jar hibernate-models-jandex-1.1.1.pom hibernate-models-1.1.1-sources.jar hibernate-models-1.1.1.pom"
-koFiles="hibernate-models-1.1.1.jar"
-# diffoscope central/org/hibernate/models/hibernate-models/1.1.1/hibernate-models-1.1.1.jar repository/org/hibernate/models/hibernate-models/1.1.1/hibernate-models-1.1.1.jar
-stabilize_ok=0
-stabilize_ko=1
-stabilize_ignored=0
-stabilize_okFiles=""
-stabilize_koFiles="hibernate-models-1.1.1.jar.stabilized"
-stabilize_ignoredFiles=""
+ok=9
+ko=0
+okFiles="hibernate-models-bytebuddy-1.1.1-sources.jar hibernate-models-bytebuddy-1.1.1.jar hibernate-models-bytebuddy-1.1.1.pom hibernate-models-jandex-1.1.1-sources.jar hibernate-models-jandex-1.1.1.jar hibernate-models-jandex-1.1.1.pom hibernate-models-1.1.1-sources.jar hibernate-models-1.1.1.jar hibernate-models-1.1.1.pom"
+koFiles=""

--- a/content/org/hibernate/models/hibernate-models/hibernate-models-1.1.1.buildinfo
+++ b/content/org/hibernate/models/hibernate-models/hibernate-models-1.1.1.buildinfo
@@ -3,7 +3,7 @@ group-id=org.hibernate.models
 artifact-id=hibernate-models
 
 build-tool=gradle
-java.version=21
+java.version=25
 os.name=lf
 
 outputs.1.coordinates=org.hibernate.models:hibernate-models-bytebuddy
@@ -43,8 +43,8 @@ outputs.3.0.length=134954
 outputs.3.0.checksums.sha512=5c6a2f82c6a9cc035a38e09d6dc5c125f00267e3b6485e8510d67accfbe9b3712f094333a51bba3e383eda56e577ec1d8f3cfaf098e88ecb309bc9dc9173e1d8
 
 outputs.3.1.filename=hibernate-models-1.1.1.jar
-outputs.3.1.length=222562
-outputs.3.1.checksums.sha512=2605af5a0c7cdc0f3635288998407f5fa1dc5a5db32052e5246bd9574ea937b57f0ce6a0618fa83b97ef50562f2ecda19c1e0e5d20f91d7195ff47824cae3d58
+outputs.3.1.length=222526
+outputs.3.1.checksums.sha512=781ff85372693dfee4f3c060af2ac8de4abb49100f5e6b9b559553f5b464b71cce03732fecc43cbd8f852de392178f24a36d0b4993f9999eda1393471688ac8c
 
 outputs.3.2.filename=hibernate-models-1.1.1.pom
 outputs.3.2.length=2116

--- a/content/org/hibernate/models/hibernate-models/hibernate-models-1.1.1.buildspec
+++ b/content/org/hibernate/models/hibernate-models/hibernate-models-1.1.1.buildspec
@@ -13,7 +13,7 @@ gitTag=${version}
 
 # Rebuild environment prerequisites
 tool=gradle
-jdk=21
+jdk=25
 newline=lf
 umask=022
 


### PR DESCRIPTION
Hey 👋🏻 🙂 

I noticed the failures for recent releases ... with version 1.1 the build switched to JDK 25 and Gradle 9.x, let's see if the re-builds agree 🤞🏻 