### PR TITLE
add bitcoinj-core-0.17.1

### DIFF
--- a/bin/includes/rebuildToolGradle.sh
+++ b/bin/includes/rebuildToolGradle.sh
@@ -26,7 +26,7 @@ rebuildToolGradle() {
 #      jdkImage="openjdk:17-slim"
 #      ;;
 #  esac
-  jdkImage="docker.io/library/gradle:9-jdk${jdk}"
+  jdkImage="docker.io/library/gradle:8-jdk${jdk}"
 
   info "Rebuilding using container image ${jdkImage}"
 

--- a/wip/bitcoinj-core-0.17.1.buildspec
+++ b/wip/bitcoinj-core-0.17.1.buildspec
@@ -1,0 +1,20 @@
+groupId=org.bitcoinj
+artifactId=bitcoinj-core
+version=0.17.1
+
+display=${groupId}:${artifactId}
+
+gitRepo=https://github.com/bitcoinj/bitcoinj.git
+gitTag=v${version}
+
+tool=gradle
+jdk=17
+newline=lf
+
+#execBefore="sed -i -e 's|dirMode = 0755|//dirMode = 0755|;s|fileMode = 0644|//fileMode = 0644|' build.gradle ; sed -i -e 's|sourceCompatibility = 8|//sourceCompatibility = 8|;s|targetCompatibility = 8|//targetCompatibility = 8|' core/build.gradle ; sed -i -e 's|sourceCompatibility = 8|//sourceCompatibility = 8|;s|targetCompatibility = 8|//targetCompatibility = 8|' core/build.gradle"
+command="gradle publishToMavenLocal"
+
+buildinfo=${artifactId}-${version}.buildinfo
+
+#diffoscope=${artifactId}-${version}.diffoscope
+issue=


### PR DESCRIPTION
This fails because `tool=gradle` results in Gradle 9 being used.

This should build successfully with Gradle 8, but the reference build uses the Debian build of Gradle 4.4.x:

https://github.com/bitcoinj/bitcoinj/tree/v0.17.1#building-the-reference-build

One reason we use the Debian build of Gradle is that it is built from source.

The commented-out `execBefore` symbol was the start of an attempt to get the build working with Gradle 9, but additional patches would be required.