### PR TITLE
add secp256k1-jdk-secp-api-0.2.1

### DIFF
--- a/wip/secp-api-0.2.1.buildspec
+++ b/wip/secp-api-0.2.1.buildspec
@@ -1,0 +1,19 @@
+groupId=org.bitcoinj.secp
+artifactId=secp-api
+version=0.2.1
+
+display=${groupId}:${artifactId}
+
+gitRepo=https://github.com/bitcoinj/secp256k1-jdk.git
+gitTag=v${version}
+
+tool=gradle
+jdk=25
+newline=lf
+
+command="gradle secp-api:publishToMavenLocal"
+
+buildinfo=${artifactId}-${version}.buildinfo
+
+#diffoscope=${artifactId}-${version}.diffoscope
+issue=


### PR DESCRIPTION
This release is not in Maven central, so the build will fail. This is WIP for the 0.2.2 release which will be published to Maven Central.