### PR TITLE
Add buildspec for webauthn4j 0.31.7

### DIFF
--- a/content/com/webauthn4j/webauthn4j-0.31.7.buildspec
+++ b/content/com/webauthn4j/webauthn4j-0.31.7.buildspec
@@ -1,0 +1,17 @@
+groupId=com.webauthn4j
+artifactId=webauthn4j-core
+version=0.31.7.RELEASE
+
+display=${groupId}:${artifactId}
+
+gitRepo=https://github.com/webauthn4j/webauthn4j.git
+gitTag=${version}
+
+tool=gradle
+jdk=25
+newline=lf
+
+command="./gradlew publishToMavenLocal -PtoolchainJdkVersion=25.0.3+9 -x test"
+
+buildinfo=${artifactId}-${version}.buildinfo
+


### PR DESCRIPTION
Add buildspec for webauthn4j 0.31.7.RELEASE.

webauthn4j is a Java library for WebAuthn/FIDO2 server-side verification.

This is my first time writing a buildspec — please let us know if anything needs adjustment.