### PR TITLE
add org.clojure/test.check 1.1.3

### DIFF
--- a/content/org/clojure/test.check/README.md
+++ b/content/org/clojure/test.check/README.md
@@ -1,0 +1,19 @@
+[org.clojure:test.check](https://central.sonatype.com/artifact/org.clojure/test.check/versions) RB check
+=======
+
+[![Reproducible Builds](https://reproducible-builds.org/images/logos/rb.svg) an independently-verifiable path from source to binary code](https://reproducible-builds.org/)
+
+## Project: [org.clojure:test.check](https://central.sonatype.com/artifact/org.clojure/test.check/versions) [![Reproducible Builds](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/jvm-repo-rebuild/reproducible-central/master/content/org/clojure/test.check/badge.json)](https://github.com/jvm-repo-rebuild/reproducible-central/blob/master/content/org/clojure/test.check/README.md)
+
+Source code: [https://github.com/clojure/test.check.git](https://github.com/clojure/test.check.git)
+
+rebuilding **1 releases** of org.clojure:test.check:
+- **0** releases were found successfully **fully reproducible** (100% reproducible artifacts :white_check_mark:),
+- 1 had issues (some unreproducible artifacts :warning:, see eventual :mag: diffoscope and/or :memo: issue tracker links):
+  - running [stabilize](doc/stabilize.md) on 1, 1 had all their differences removed :recycle:
+
+| version | [build spec](/BUILDSPEC.md) | [result](https://reproducible-builds.org/docs/jvm/): reproducible? | [stabilize](https://github.com/google/oss-rebuild/blob/main/cmd/stabilize/README.md) | size |
+| -- | --------- | ------ | ------ | -- |
+| [1.1.3](https://central.sonatype.com/artifact/org.clojure/test.check/1.1.3/pom) | [mvn jdk8](test.check-1.1.3.buildspec) | [result](test.check-1.1.3.buildinfo): [1 :white_check_mark:  2 :warning:](test.check-1.1.3.buildcompare) [:mag:](test.check-1.1.3.diffoscope) | 2 :recycle: | 81K |
+
+<i>(size is calculated without javadoc, that has been excluded from reproducibility checks)</i>

--- a/content/org/clojure/test.check/badge.json
+++ b/content/org/clojure/test.check/badge.json
@@ -1,0 +1,6 @@
+{ "schemaVersion": 1,
+  "label": "Reproducible Builds",
+  "labelColor": "1e5b96",
+  "message": "1/3",
+  "color": "red",
+  "isError": "true" }

--- a/content/org/clojure/test.check/maven-metadata.xml
+++ b/content/org/clojure/test.check/maven-metadata.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<metadata>
+  <groupId>org.clojure</groupId>
+  <artifactId>test.check</artifactId>
+  <versioning>
+    <latest>1.1.3</latest>
+    <release>1.1.3</release>
+    <versions>
+      <version>0.5.7</version>
+      <version>0.5.8</version>
+      <version>0.5.9</version>
+      <version>0.6.0</version>
+      <version>0.6.1</version>
+      <version>0.6.2</version>
+      <version>0.7.0</version>
+      <version>0.8.0-ALPHA</version>
+      <version>0.8.0-alpha2</version>
+      <version>0.8.0-alpha3</version>
+      <version>0.8.0-RC1</version>
+      <version>0.8.0-RC2</version>
+      <version>0.8.0-RC3</version>
+      <version>0.8.0</version>
+      <version>0.8.1</version>
+      <version>0.8.2</version>
+      <version>0.9.0</version>
+      <version>0.10.0-alpha1</version>
+      <version>0.10.0-alpha2</version>
+      <version>0.10.0-alpha3</version>
+      <version>0.10.0-alpha4</version>
+      <version>0.10.0-RC1</version>
+      <version>0.10.0</version>
+      <version>1.0.0</version>
+      <version>1.1.0</version>
+      <version>1.1.1</version>
+      <version>1.1.2</version>
+      <version>1.1.3</version>
+    </versions>
+    <lastUpdated>20251230192514</lastUpdated>
+  </versioning>
+</metadata>

--- a/content/org/clojure/test.check/test.check-1.1.3.buildcompare
+++ b/content/org/clojure/test.check/test.check-1.1.3.buildcompare
@@ -1,0 +1,17 @@
+version=1.1.3
+ok=1
+ko=2
+ignored=0
+okFiles="test.check-1.1.3.pom"
+koFiles="test.check-1.1.3.jar test.check-1.1.3-sources.jar"
+ignoredFiles=""
+reference_java_version="1.8 (from MANIFEST.MF Build-Jdk-Spec)"
+reference_os_name="Unix (from pom.properties newline)"
+# diffoscope target/reference/org.clojure/test.check-1.1.3.jar target/test.check-1.1.3.jar
+# diffoscope target/reference/org.clojure/test.check-1.1.3-sources.jar target/test.check-1.1.3-sources.jar
+stabilize_ok=2
+stabilize_ko=0
+stabilize_ignored=0
+stabilize_okFiles="test.check-1.1.3.jar.stabilized test.check-1.1.3-sources.jar.stabilized"
+stabilize_koFiles=""
+stabilize_ignoredFiles=""

--- a/content/org/clojure/test.check/test.check-1.1.3.buildinfo
+++ b/content/org/clojure/test.check/test.check-1.1.3.buildinfo
@@ -1,0 +1,42 @@
+# https://reproducible-builds.org/docs/jvm/
+buildinfo.version=1.0-SNAPSHOT
+
+name=test.check
+group-id=org.clojure
+artifact-id=test.check
+version=1.1.3
+
+# source information
+source.scm.uri=scm:git:git://github.com/clojure/test.check.git
+source.scm.tag=v1.1.3
+
+# build instructions
+build-tool=mvn
+
+# effective build environment information
+java.version=1.8.0_492
+java.vendor=Private Build
+os.name=Linux
+os.version=6.17.0-1018-azure
+os.arch=amd64
+line.separator=\n
+
+# Maven rebuild instructions and effective environment
+mvn.version=3.9.11
+
+# output
+
+outputs.0.groupId=org.clojure
+outputs.0.filename=test.check-1.1.3.pom
+outputs.0.length=1630
+outputs.0.checksums.sha512=e1eeb1fe3d3add6e01fe61fc8a8d0630916d624e7494e993aafa453785424213604de3c7fd3349fe43469c86c187898f1cd8675f233e31a8ef85bef8e684a3fb
+
+outputs.1.groupId=org.clojure
+outputs.1.filename=test.check-1.1.3.jar
+outputs.1.length=40187
+outputs.1.checksums.sha512=ac65e8d52b13f6fa3772e0df47a50f639b989260b7cd93afa04f64cd6d12d4963a649c0ef90668641776b900d02a5319e511511ec58973a91a6f681f598f2173
+
+outputs.2.groupId=org.clojure
+outputs.2.filename=test.check-1.1.3-sources.jar
+outputs.2.length=40171
+outputs.2.checksums.sha512=6cfbe4b4381e44dcc3bd6d215f7b2fe95c104091e4efdc12a8d5fb4ccf513b0a077a3c0a19fd347ba5b31c5172441f60f06c1fdae08c8fd5fde9fdbdf47eb94a

--- a/content/org/clojure/test.check/test.check-1.1.3.buildspec
+++ b/content/org/clojure/test.check/test.check-1.1.3.buildspec
@@ -1,0 +1,18 @@
+groupId=org.clojure
+artifactId=test.check
+display=${groupId}:${artifactId}
+version=1.1.3
+
+gitRepo=https://github.com/clojure/test.check.git
+gitTag=v${version}
+
+tool=mvn-3.9.11
+jdk=8
+newline=lf
+umask=022
+
+command="mvn -ntp -B clean package -Dmaven.test.skip=true -Dmaven.javadoc.skip -Dgpg.skip source:jar"
+buildinfo=target/${artifactId}-${version}.buildinfo
+
+diffoscope=${artifactId}-${version}.diffoscope
+issue=

--- a/content/org/clojure/test.check/test.check-1.1.3.diffoscope
+++ b/content/org/clojure/test.check/test.check-1.1.3.diffoscope
@@ -1,0 +1,233 @@
+1 / 2 target/reference/org.clojure/test.check-1.1.3.jar target/test.check-1.1.3.jar
+--- target/reference/org.clojure/test.check-1.1.3.jar
++++ target/test.check-1.1.3.jar
+├── zipnote «TEMP»/diffoscope_0iq15tjq_target/tmpx4mhkrf5_.zip
+│ @@ -9,75 +9,75 @@
+│  
+│  Filename: clojure/test/
+│  Comment: 
+│  
+│  Filename: clojure/test/check/
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/random/
+│ +Filename: clojure/test/check/clojure_test/
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/random/longs/
+│ +Filename: clojure/test/check/clojure_test/assertions/
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/clojure_test/
+│ +Filename: clojure/test/check/random/
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/clojure_test/assertions/
+│ +Filename: clojure/test/check/random/longs/
+│  Comment: 
+│  
+│  Filename: META-INF/maven/
+│  Comment: 
+│  
+│  Filename: META-INF/maven/org.clojure/
+│  Comment: 
+│  
+│  Filename: META-INF/maven/org.clojure/test.check/
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/random.cljs
+│ +Filename: clojure/test/check.cljc
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/random/doubles.cljs
+│ +Filename: clojure/test/check/rose_tree.cljc
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/random/longs/bit_count_impl.cljs
+│ +Filename: clojure/test/check/clojure_test/assertions.cljc
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/random/longs.cljs
+│ +Filename: clojure/test/check/clojure_test/assertions/cljs.cljc
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/random.clj
+│ +Filename: clojure/test/check/random/longs/bit_count_impl.cljs
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/clojure_test.cljc
+│ +Filename: clojure/test/check/random/longs.cljs
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/clojure_test/assertions/cljs.cljc
+│ +Filename: clojure/test/check/random/doubles.cljs
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/clojure_test/assertions.cljc
+│ +Filename: clojure/test/check/generators.cljc
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/results.cljc
+│ +Filename: clojure/test/check/properties.cljc
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/generators.cljc
+│ +Filename: clojure/test/check/random.cljs
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/impl.cljc
+│ +Filename: clojure/test/check/clojure_test.cljc
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/properties.cljc
+│ +Filename: clojure/test/check/random.clj
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/rose_tree.cljc
+│ +Filename: clojure/test/check/impl.cljc
+│  Comment: 
+│  
+│ -Filename: clojure/test/check.cljc
+│ +Filename: clojure/test/check/results.cljc
+│  Comment: 
+│  
+│  Filename: META-INF/maven/org.clojure/test.check/pom.xml
+│  Comment: 
+│  
+│  Filename: META-INF/maven/org.clojure/test.check/pom.properties
+│  Comment:
+├── zipdetails --redact --walk --utc {}
+│ @@ -1,15 +1,15 @@
+│  
+│  0000 LOCAL HEADER #1       04034B50 (67324752)
+│  0004 Extract Zip Spec      0A (10) '1.0'
+│  0005 Extract OS            00 (0) 'MS-DOS'
+│  0006 General Purpose Flag  0800 (2048)
+│       [Bit 11]              1 'Language Encoding'
+│  0008 Compression Method    0000 (0) 'Stored'
+│ -000A Modification Time     5B9E9A94 (1537120916) 'Tue Dec 30 19:20:40 2025'
+│ +000A Modification Time     5CCEB833 (1557051443) 'Sun Jun 14 23:01:38 2026'
+│  000E CRC                   00000000 (0)
+│  0012 Compressed Size       00000000 (0)
+│  0016 Uncompressed Size     00000000 (0)
+│  001A Filename Length       0009 (9)
+│  001C Extra Length          0000 (0)
+│  001E Filename              'XXXXXXXXX'
+│  #
+
+2 / 2 target/reference/org.clojure/test.check-1.1.3-sources.jar target/test.check-1.1.3-sources.jar
+--- target/reference/org.clojure/test.check-1.1.3-sources.jar
++++ target/test.check-1.1.3-sources.jar
+├── zipnote «TEMP»/diffoscope__gm2amk2_target/tmp122n_qjg_.zip
+│ @@ -9,75 +9,75 @@
+│  
+│  Filename: clojure/test/
+│  Comment: 
+│  
+│  Filename: clojure/test/check/
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/random/
+│ +Filename: clojure/test/check/clojure_test/
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/random/longs/
+│ +Filename: clojure/test/check/clojure_test/assertions/
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/clojure_test/
+│ +Filename: clojure/test/check/random/
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/clojure_test/assertions/
+│ +Filename: clojure/test/check/random/longs/
+│  Comment: 
+│  
+│  Filename: META-INF/maven/
+│  Comment: 
+│  
+│  Filename: META-INF/maven/org.clojure/
+│  Comment: 
+│  
+│  Filename: META-INF/maven/org.clojure/test.check/
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/random.cljs
+│ +Filename: clojure/test/check.cljc
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/random/doubles.cljs
+│ +Filename: clojure/test/check/rose_tree.cljc
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/random/longs/bit_count_impl.cljs
+│ +Filename: clojure/test/check/clojure_test/assertions.cljc
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/random/longs.cljs
+│ +Filename: clojure/test/check/clojure_test/assertions/cljs.cljc
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/random.clj
+│ +Filename: clojure/test/check/random/longs/bit_count_impl.cljs
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/clojure_test.cljc
+│ +Filename: clojure/test/check/random/longs.cljs
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/clojure_test/assertions/cljs.cljc
+│ +Filename: clojure/test/check/random/doubles.cljs
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/clojure_test/assertions.cljc
+│ +Filename: clojure/test/check/generators.cljc
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/results.cljc
+│ +Filename: clojure/test/check/properties.cljc
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/generators.cljc
+│ +Filename: clojure/test/check/random.cljs
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/impl.cljc
+│ +Filename: clojure/test/check/clojure_test.cljc
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/properties.cljc
+│ +Filename: clojure/test/check/random.clj
+│  Comment: 
+│  
+│ -Filename: clojure/test/check/rose_tree.cljc
+│ +Filename: clojure/test/check/impl.cljc
+│  Comment: 
+│  
+│ -Filename: clojure/test/check.cljc
+│ +Filename: clojure/test/check/results.cljc
+│  Comment: 
+│  
+│  Filename: META-INF/maven/org.clojure/test.check/pom.xml
+│  Comment: 
+│  
+│  Filename: META-INF/maven/org.clojure/test.check/pom.properties
+│  Comment:
+├── zipdetails --redact --walk --utc {}
+│ @@ -1,15 +1,15 @@
+│  
+│  0000 LOCAL HEADER #1       04034B50 (67324752)
+│  0004 Extract Zip Spec      0A (10) '1.0'
+│  0005 Extract OS            00 (0) 'MS-DOS'
+│  0006 General Purpose Flag  0800 (2048)
+│       [Bit 11]              1 'Language Encoding'
+│  0008 Compression Method    0000 (0) 'Stored'
+│ -000A Modification Time     5B9E9A95 (1537120917) 'Tue Dec 30 19:20:42 2025'
+│ +000A Modification Time     5CCEB833 (1557051443) 'Sun Jun 14 23:01:38 2026'
+│  000E CRC                   00000000 (0)
+│  0012 Compressed Size       00000000 (0)
+│  0016 Uncompressed Size     00000000 (0)
+│  001A Filename Length       0009 (9)
+│  001C Extra Length          0000 (0)
+│  001E Filename              'XXXXXXXXX'
+│  #


### PR DESCRIPTION
https://github.com/frenchy64/reproducible-central/blob/test-check/content/org/clojure/test.check/README.md#project-orgclojuretestcheck-

test.check is a source-only Clojure library. No attempt at reproducibility has been made yet.

According to diffoscope, zip order and timestamps are the main non-reproducible elements. Here's the pom.xml: https://github.com/clojure/test.check/blob/master/pom.xml

I'm happy to take suggestions on how to address this, I can follow up with the project to add reproducibility.