### PR TITLE
Switch to JDK 25 for building Hibernate Reactive

### DIFF
--- a/content/org/hibernate/reactive/hibernate-reactive/README.md
+++ b/content/org/hibernate/reactive/hibernate-reactive/README.md
@@ -8,13 +8,12 @@
 Source code: [https://github.com/hibernate/hibernate-reactive.git](https://github.com/hibernate/hibernate-reactive.git)
 
 rebuilding **120 releases** of org.hibernate.reactive:hibernate-reactive-core:
-- **119** releases were found successfully **fully reproducible** (100% reproducible artifacts :white_check_mark:),
-- 1 had issues (some unreproducible artifacts :warning:, see eventual :mag: diffoscope and/or :memo: issue tracker links):
-  - running [stabilize](doc/stabilize.md) on 1, 0 had all their differences removed :recycle:, 1 still had differences :rotating_light: or files not supported by stabilize :no_entry_sign:
+- **120** releases were found successfully **fully reproducible** (100% reproducible artifacts :white_check_mark:),
+- 0 had issues (some unreproducible artifacts :warning:, see eventual :mag: diffoscope and/or :memo: issue tracker links):
 
 | version | [build spec](/BUILDSPEC.md) | [result](https://reproducible-builds.org/docs/jvm/): reproducible? | [stabilize](https://github.com/google/oss-rebuild/blob/main/cmd/stabilize/README.md) | size |
 | -- | --------- | ------ | ------ | -- |
-| [4.5.1.Final](https://central.sonatype.com/artifact/org.hibernate.reactive/hibernate-reactive-core/4.5.1.Final/pom) | [gradle jdk17](hibernate-reactive-4.5.1.Final.buildspec) | [result](hibernate-reactive-core-4.5.1.Final.buildinfo): [2 :white_check_mark:  1 :warning:](hibernate-reactive-core-4.5.1.Final.buildcompare) | 1 :rotating_light: | 2.1M |
+| [4.5.1.Final](https://central.sonatype.com/artifact/org.hibernate.reactive/hibernate-reactive-core/4.5.1.Final/pom) | [gradle jdk25](hibernate-reactive-4.5.1.Final.buildspec) | [result](hibernate-reactive-core-4.5.1.Final.buildinfo): [3 :white_check_mark: ](hibernate-reactive-core-4.5.1.Final.buildcompare) | | 2.1M |
 | [4.5.0.Final](https://central.sonatype.com/artifact/org.hibernate.reactive/hibernate-reactive-core/4.5.0.Final/pom) | [gradle jdk17](hibernate-reactive-4.5.0.Final.buildspec) | [result](hibernate-reactive-core-4.5.0.Final.buildinfo): [3 :white_check_mark: ](hibernate-reactive-core-4.5.0.Final.buildcompare) | | 2.1M |
 | [4.5.0.CR1](https://central.sonatype.com/artifact/org.hibernate.reactive/hibernate-reactive-core/4.5.0.CR1/pom) | [gradle jdk17](hibernate-reactive-4.5.0.CR1.buildspec) | [result](hibernate-reactive-core-4.5.0.CR1.buildinfo): [3 :white_check_mark: ](hibernate-reactive-core-4.5.0.CR1.buildcompare) | | 2.0M |
 | [4.4.1.Final](https://central.sonatype.com/artifact/org.hibernate.reactive/hibernate-reactive-core/4.4.1.Final/pom) | [gradle jdk17](hibernate-reactive-4.4.1.Final.buildspec) | [result](hibernate-reactive-core-4.4.1.Final.buildinfo): [3 :white_check_mark: ](hibernate-reactive-core-4.4.1.Final.buildcompare) | | 2.0M |

--- a/content/org/hibernate/reactive/hibernate-reactive/badge.json
+++ b/content/org/hibernate/reactive/hibernate-reactive/badge.json
@@ -1,6 +1,6 @@
 { "schemaVersion": 1,
   "label": "Reproducible Builds",
   "labelColor": "1e5b96",
-  "message": "2/3",
-  "color": "yellow",
+  "message": "3/3",
+  "color": "green",
   "isError": "true" }

--- a/content/org/hibernate/reactive/hibernate-reactive/hibernate-reactive-4.5.1.Final.buildspec
+++ b/content/org/hibernate/reactive/hibernate-reactive/hibernate-reactive-4.5.1.Final.buildspec
@@ -13,7 +13,7 @@ gitTag=$(echo "$version" | sed -e 's/.Final//')
 
 # Rebuild environment prerequisites
 tool=gradle
-jdk=17
+jdk=25
 newline=lf
 umask=022
 

--- a/content/org/hibernate/reactive/hibernate-reactive/hibernate-reactive-core-4.5.1.Final.buildcompare
+++ b/content/org/hibernate/reactive/hibernate-reactive/hibernate-reactive-core-4.5.1.Final.buildcompare
@@ -1,12 +1,5 @@
 version=4.5.1.Final
-ok=2
-ko=1
-okFiles="hibernate-reactive-core-4.5.1.Final-sources.jar hibernate-reactive-core-4.5.1.Final.pom"
-koFiles="hibernate-reactive-core-4.5.1.Final.jar"
-# diffoscope central/org/hibernate/reactive/hibernate-reactive-core/4.5.1.Final/hibernate-reactive-core-4.5.1.Final.jar repository/org/hibernate/reactive/hibernate-reactive-core/4.5.1.Final/hibernate-reactive-core-4.5.1.Final.jar
-stabilize_ok=0
-stabilize_ko=1
-stabilize_ignored=0
-stabilize_okFiles=""
-stabilize_koFiles="hibernate-reactive-core-4.5.1.Final.jar.stabilized"
-stabilize_ignoredFiles=""
+ok=3
+ko=0
+okFiles="hibernate-reactive-core-4.5.1.Final-sources.jar hibernate-reactive-core-4.5.1.Final.jar hibernate-reactive-core-4.5.1.Final.pom"
+koFiles=""

--- a/content/org/hibernate/reactive/hibernate-reactive/hibernate-reactive-core-4.5.1.Final.buildinfo
+++ b/content/org/hibernate/reactive/hibernate-reactive/hibernate-reactive-core-4.5.1.Final.buildinfo
@@ -3,7 +3,7 @@ group-id=org.hibernate.reactive
 artifact-id=hibernate-reactive-core
 
 build-tool=gradle
-java.version=17
+java.version=25
 os.name=lf
 
 outputs.1.coordinates=org.hibernate.reactive:hibernate-reactive-core
@@ -13,8 +13,8 @@ outputs.1.0.length=695109
 outputs.1.0.checksums.sha512=4ffe6676db2680e98e7c521cd96f7084012f7827b594127820ad21129d55f7a1232a1ba2a80d3183a5a77c0a2da2bda1086f2ddc42645f745db905bd2aba58f8
 
 outputs.1.1.filename=hibernate-reactive-core-4.5.1.Final.jar
-outputs.1.1.length=1402168
-outputs.1.1.checksums.sha512=202307b1bf64b1bef55389962ed3ebd276cb170c861e239b9e41a129af45dfd06295db4c7869c9678ab7c9f6216170cb0dbf998bdc1a8d9c077ea433a0b444f6
+outputs.1.1.length=1402294
+outputs.1.1.checksums.sha512=d35b93694bc0c86aaf3c5955f6e30907b01868c8cc890a4f5a97aa0dd53d5879c8bffcc9ad8f7fb4ab8bb875856dad31e5908ada9ec42d0084d508740e790af8
 
 outputs.1.2.filename=hibernate-reactive-core-4.5.1.Final.pom
 outputs.1.2.length=2807


### PR DESCRIPTION
Hello 🙂 👋🏻 
we've switched to building releases with JDK 25 in Hibernate Reactive ... let's see if this also helps with the failed check 🤞🏻 