### PR TITLE
./rebuild.sh content/io/github/chains-project/maven-lockfile/maven-lockfile-5.18.2.buildspec

### DIFF
--- a/content/io/github/chains-project/maven-lockfile/README.md
+++ b/content/io/github/chains-project/maven-lockfile/README.md
@@ -14,12 +14,13 @@ Source code: [https://github.com/chains-project/maven-lockfile.git](https://gith
 * [io.github.chains-project:maven-lockfile-parent](https://central.sonatype.com/artifact/io.github.chains-project/maven-lockfile-parent/overview)
 </details>
 
-rebuilding **102 releases** of io.github.chains-project:maven-lockfile:
-- **65** releases were found successfully **fully reproducible** (100% reproducible artifacts :white_check_mark:),
+rebuilding **103 releases** of io.github.chains-project:maven-lockfile:
+- **66** releases were found successfully **fully reproducible** (100% reproducible artifacts :white_check_mark:),
 - 37 had issues (some unreproducible artifacts :warning:, see eventual :mag: diffoscope and/or :memo: issue tracker links):
 
 | version | [build spec](/BUILDSPEC.md) | [result](https://reproducible-builds.org/docs/jvm/): reproducible? | [stabilize](https://github.com/google/oss-rebuild/blob/main/cmd/stabilize/README.md) | size |
 | -- | --------- | ------ | ------ | -- |
+| [5.18.2](https://central.sonatype.com/artifact/io.github.chains-project/maven-lockfile/5.18.2/pom) | [mvn jdk17](maven-lockfile-5.18.2.buildspec) | [result](maven-lockfile-5.18.2.buildinfo): [6 :white_check_mark: ](maven-lockfile-5.18.2.buildcompare) | | 686K |
 | [5.18.1](https://central.sonatype.com/artifact/io.github.chains-project/maven-lockfile/5.18.1/pom) | [mvn jdk17](maven-lockfile-5.18.1.buildspec) | [result](maven-lockfile-5.18.1.buildinfo): [6 :white_check_mark: ](maven-lockfile-5.18.1.buildcompare) | | 684K |
 | [5.18.1-beta-1](https://central.sonatype.com/artifact/io.github.chains-project/maven-lockfile/5.18.1-beta-1/pom) | [mvn jdk17](maven-lockfile-5.18.1-beta-1.buildspec) | [result](maven-lockfile-5.18.1-beta-1.buildinfo): [6 :white_check_mark: ](maven-lockfile-5.18.1-beta-1.buildcompare) | | 685K |
 | [5.18.0](https://central.sonatype.com/artifact/io.github.chains-project/maven-lockfile/5.18.0/pom) | [mvn jdk17](maven-lockfile-5.18.0.buildspec) | [result](maven-lockfile-5.18.0.buildinfo): [6 :white_check_mark: ](maven-lockfile-5.18.0.buildcompare) | | 684K |

--- a/content/io/github/chains-project/maven-lockfile/maven-lockfile-5.18.2.buildcompare
+++ b/content/io/github/chains-project/maven-lockfile/maven-lockfile-5.18.2.buildcompare
@@ -1,0 +1,9 @@
+version=5.18.2
+ok=6
+ko=0
+ignored=0
+okFiles="maven-lockfile-5.18.2.pom maven-lockfile-5.18.2.jar maven-lockfile-5.18.2-cyclonedx.xml maven-lockfile-5.18.2-cyclonedx.json maven-lockfile-5.18.2-sources.jar maven-lockfile-5.18.2-tests.jar"
+koFiles=""
+ignoredFiles=""
+reference_java_version="17 (from MANIFEST.MF Build-Jdk-Spec)"
+reference_os_name="Unix (from pom.properties newline)"

--- a/content/io/github/chains-project/maven-lockfile/maven-lockfile-5.18.2.buildinfo
+++ b/content/io/github/chains-project/maven-lockfile/maven-lockfile-5.18.2.buildinfo
@@ -1,0 +1,58 @@
+# https://reproducible-builds.org/docs/jvm/
+buildinfo.version=1.0-SNAPSHOT
+
+name=maven-lockfile-plugin
+group-id=io.github.chains-project
+artifact-id=maven-lockfile
+version=5.18.2
+
+# source information
+source.scm.uri=scm:git:https://github.com/chains-project/maven-lockfile
+source.scm.tag=v5.18.2
+
+# build instructions
+build-tool=mvn
+
+# effective build environment information
+java.version=17.0.20
+java.vendor=Ubuntu
+os.name=Linux
+os.version=6.17.0-1022-azure
+os.arch=amd64
+line.separator=\n
+
+# Maven rebuild instructions and effective environment
+mvn.version=3.9.12
+mvn.minimum.version=3.2.5
+
+# output
+
+outputs.0.groupId=io.github.chains-project
+outputs.0.filename=maven-lockfile-5.18.2.pom
+outputs.0.length=17997
+outputs.0.checksums.sha512=c68d1d48557fda2de072d38ed4206166b5c438a165dcd0a04925a930f88258a3957cc747f5582a8c53edc70df750e6244c0117aeb1c8113aefd878db432690e1
+
+outputs.1.groupId=io.github.chains-project
+outputs.1.filename=maven-lockfile-5.18.2.jar
+outputs.1.length=149784
+outputs.1.checksums.sha512=25c0a02bbb7706ccbed71c7245729c57d15ac49c2ca797c922f19c6e9c65738f3e9c684b1149d380fbc94208db6eaa121ae92e3848fdccaa1c221ed66b6ca473
+
+outputs.2.groupId=io.github.chains-project
+outputs.2.filename=maven-lockfile-5.18.2-cyclonedx.xml
+outputs.2.length=190064
+outputs.2.checksums.sha512=bc975fb68b0121b73476bec83eb5cb22e725ecd5e737afcfbda48cf68c8bc43e90f7953523831770eff6cac5c5679b4c24e2c36eb0b2a16eb5fc8b51c4271240
+
+outputs.3.groupId=io.github.chains-project
+outputs.3.filename=maven-lockfile-5.18.2-cyclonedx.json
+outputs.3.length=207523
+outputs.3.checksums.sha512=9af7ea1b0479f59ef995f833c3fd762fb5a6a8587da1afb3c71770b6b5f56ea121d2ee22029a08ceb68663047cf353c358408805b87b071e8b510b56ac403a58
+
+outputs.4.groupId=io.github.chains-project
+outputs.4.filename=maven-lockfile-5.18.2-sources.jar
+outputs.4.length=71307
+outputs.4.checksums.sha512=ee48bf1748b5565ae09c3395736a10013ea16d7b1ca0f9f9eb9f7d585007f50b1bae7a151b187802b068d41645b7009587c5d77cf246d92f354f0f17894609c7
+
+outputs.5.groupId=io.github.chains-project
+outputs.5.filename=maven-lockfile-5.18.2-tests.jar
+outputs.5.length=64806
+outputs.5.checksums.sha512=d62024b7b093a65b976641e81aae958934174010b3bca7b9cef96bfa88a966a3e26159c76cf77a663cf1691cdaf3e5f2d2447803a191046872f02337209dbcaa

--- a/content/io/github/chains-project/maven-lockfile/maven-lockfile-5.18.2.buildspec
+++ b/content/io/github/chains-project/maven-lockfile/maven-lockfile-5.18.2.buildspec
@@ -1,0 +1,18 @@
+groupId=io.github.chains-project
+artifactId=maven-lockfile
+display=${groupId}:${artifactId}
+version=5.18.2
+
+gitRepo=https://github.com/chains-project/${artifactId}.git
+gitTag=v${version}
+
+tool=mvn-3.9.12
+jdk=17
+newline=lf
+umask=022
+
+command="mvn -Ppublication clean package -DskipTests -Dmaven.javadoc.skip -Dgpg.skip"
+buildinfo=target/${artifactId}-${version}.buildinfo
+
+#diffoscope=${artifactId}-${version}.diffoscope
+issue=

--- a/content/io/github/chains-project/maven-lockfile/maven-metadata.xml
+++ b/content/io/github/chains-project/maven-lockfile/maven-metadata.xml
@@ -3,8 +3,8 @@
   <groupId>io.github.chains-project</groupId>
   <artifactId>maven-lockfile</artifactId>
   <versioning>
-    <latest>5.18.1</latest>
-    <release>5.18.1</release>
+    <latest>5.18.2</latest>
+    <release>5.18.2</release>
     <versions>
       <version>1.0.1</version>
       <version>1.0.2</version>
@@ -134,7 +134,8 @@
       <version>5.18.0</version>
       <version>5.18.1-beta-1</version>
       <version>5.18.1</version>
+      <version>5.18.2</version>
     </versions>
-    <lastUpdated>20260830205123</lastUpdated>
+    <lastUpdated>20260901092722</lastUpdated>
   </versioning>
 </metadata>


### PR DESCRIPTION
Fixes https://github.com/chains-project/maven-lockfile/issues/1634.

## Summary
- Add buildspec for `io.github.chains-project:maven-lockfile:5.18.2`
- The `released.version` workaround used in prior buildspecs (5.18.0, 5.18.1) for https://github.com/chains-project/maven-lockfile/issues/1634 is no longer needed for this release.

## Testing
- Verified locally with `./rebuild.sh content/io/github/chains-project/maven-lockfile/maven-lockfile-5.18.2.buildspec` — build is reproducible (`ok=6`, no issue found).